### PR TITLE
Cleanups

### DIFF
--- a/components/ecodan/__init__.py
+++ b/components/ecodan/__init__.py
@@ -5,7 +5,7 @@ from esphome.const import CONF_ID, CONF_RX_PIN, CONF_TX_PIN
 
 CODEOWNERS = ["@gekkekoe"]
 
-AUTO_LOAD = ["sensor", "text_sensor"]
+AUTO_LOAD = ["binary_sensor", "sensor", "text_sensor"]
 
 CONF_ECODAN_ID = "ecodan_id"
 

--- a/components/ecodan/binary_sensor.py
+++ b/components/ecodan/binary_sensor.py
@@ -1,0 +1,105 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor
+from esphome.const import CONF_ID
+from esphome.const import (
+    ENTITY_CATEGORY_NONE,
+    DEVICE_CLASS_RUNNING,
+)
+
+from . import ECODAN, CONF_ECODAN_ID
+
+
+AUTO_LOAD = ["ecodan"]
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ECODAN_ID): cv.use_id(ECODAN),
+        cv.Optional("status_defrost"): binary_sensor.binary_sensor_schema(
+            icon="mdi:snowflake-melt",
+            entity_category=ENTITY_CATEGORY_NONE,
+            device_class=DEVICE_CLASS_RUNNING,
+        ),
+        cv.Optional("status_dhw_forced"): binary_sensor.binary_sensor_schema(
+            icon="mdi:water-boiler-alert",
+            entity_category=ENTITY_CATEGORY_NONE,
+        ),
+        cv.Optional("status_holiday"): binary_sensor.binary_sensor_schema(
+            icon="mdi:beach",
+            entity_category=ENTITY_CATEGORY_NONE,
+        ),
+        cv.Optional("status_booster"): binary_sensor.binary_sensor_schema(
+            icon="mdi:water-boiler",
+            entity_category=ENTITY_CATEGORY_NONE,
+            device_class=DEVICE_CLASS_RUNNING,
+        ),
+        cv.Optional("status_immersion"): binary_sensor.binary_sensor_schema(
+            icon="mdi:water-boiler",
+            entity_category=ENTITY_CATEGORY_NONE,
+            device_class=DEVICE_CLASS_RUNNING,
+        ),
+        cv.Optional("status_in1_request"): binary_sensor.binary_sensor_schema(
+            icon="mdi:thermostat",
+            entity_category=ENTITY_CATEGORY_NONE,
+        ),
+        cv.Optional("status_in6_request"): binary_sensor.binary_sensor_schema(
+            icon="mdi:thermostat",
+            entity_category=ENTITY_CATEGORY_NONE,
+        ),
+        cv.Optional("status_in5_request"): binary_sensor.binary_sensor_schema(
+            icon="mdi:thermostat",
+            entity_category=ENTITY_CATEGORY_NONE,
+        ),
+        cv.Optional("status_water_pump"): binary_sensor.binary_sensor_schema(
+            icon="mdi:water-pump",
+            entity_category=ENTITY_CATEGORY_NONE,
+            device_class=DEVICE_CLASS_RUNNING,
+        ),
+        cv.Optional("status_three_way_valve"): binary_sensor.binary_sensor_schema(
+            icon="mdi:valve",
+            entity_category=ENTITY_CATEGORY_NONE,
+            device_class=DEVICE_CLASS_RUNNING,
+        ),
+        cv.Optional("status_water_pump_2"): binary_sensor.binary_sensor_schema(
+            icon="mdi:water-pump",
+            entity_category=ENTITY_CATEGORY_NONE,
+            device_class=DEVICE_CLASS_RUNNING,
+        ),
+        cv.Optional("status_three_way_valve_2"): binary_sensor.binary_sensor_schema(
+            icon="mdi:valve",
+            entity_category=ENTITY_CATEGORY_NONE,
+            device_class=DEVICE_CLASS_RUNNING,
+        ),
+        cv.Optional("status_prohibit_dhw"): binary_sensor.binary_sensor_schema(
+            icon="mdi:water-boiler-off",
+            entity_category=ENTITY_CATEGORY_NONE,
+        ),
+        cv.Optional("status_prohibit_heating_z1"): binary_sensor.binary_sensor_schema(
+            icon="mdi:radiator-off",
+            entity_category=ENTITY_CATEGORY_NONE,
+        ),
+        cv.Optional("status_prohibit_cool_z1"): binary_sensor.binary_sensor_schema(
+            icon="mdi:hvac-off",
+            entity_category=ENTITY_CATEGORY_NONE,
+        ),
+        cv.Optional("status_prohibit_heating_z2"): binary_sensor.binary_sensor_schema(
+            icon="mdi:radiator-off",
+            entity_category=ENTITY_CATEGORY_NONE,
+        ),
+        cv.Optional("status_prohibit_cool_z2"): binary_sensor.binary_sensor_schema(
+            icon="mdi:hvac-off",
+            entity_category=ENTITY_CATEGORY_NONE,
+        ),
+
+    }).extend(cv.COMPONENT_SCHEMA)
+
+async def to_code(config):
+    hp = await cg.get_variable(config[CONF_ECODAN_ID])
+
+    for key, conf in config.items():
+        if not isinstance(conf, dict):
+            continue
+        id = conf.get("id")
+        if id and id.type == binary_sensor.BinarySensor:
+            sens = await binary_sensor.new_binary_sensor(conf)
+            cg.add(hp.register_binarySensor(sens, key))

--- a/components/ecodan/ecodan.cpp
+++ b/components/ecodan/ecodan.cpp
@@ -46,6 +46,17 @@ namespace ecodan
         }
     }
 
+    void EcodanHeatpump::publish_state(const std::string& sensorKey, bool sensorValue) {
+        auto binarySensor_it = binarySensors.find(sensorKey);
+        if (binarySensor_it != binarySensors.end()) {
+            binarySensor_it->second->publish_state(sensorValue);
+        }
+        else 
+        {
+            ESP_LOGI(TAG, "Could not publish state of sensor '%s' with value: '%d'", sensorKey.c_str(), sensorValue);
+        }
+    }
+
     void EcodanHeatpump::update() {        
         //ESP_LOGI(TAG, "Update() on core %d", xPortGetCoreID());
         if (heatpumpInitialized)

--- a/components/ecodan/ecodan.h
+++ b/components/ecodan/ecodan.h
@@ -8,6 +8,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
 
 #include "proto.h"
 #include "status.h"
@@ -34,6 +35,10 @@ namespace ecodan
             textSensors[key] = obj;
         }
 
+        void register_binarySensor(binary_sensor::BinarySensor *obj, const std::string& key) {
+            binarySensors[key] = obj;
+        }
+
         // exposed as external component commands
         void set_room_temperature(float value, esphome::ecodan::SetZone zone);
         void set_flow_target_temperature(float value, esphome::ecodan::SetZone zone);
@@ -48,10 +53,12 @@ namespace ecodan
     protected:
         std::map<std::string, sensor::Sensor*> sensors;
         std::map<std::string, text_sensor::TextSensor*> textSensors;
+        std::map<std::string, binary_sensor::BinarySensor*> binarySensors;
 
         // publish func
         void publish_state(const std::string& sensorKey, float sensorValue);
         void publish_state(const std::string& sensorKey, const std::string& sensorValue);
+        void publish_state(const std::string& sensorKey, bool sensorValue);
 
         bool begin_connect();
         bool begin_update_status();

--- a/components/ecodan/response.cpp
+++ b/components/ecodan/response.cpp
@@ -10,7 +10,7 @@ namespace ecodan
             {
             case GetType::DEFROST_STATE:
                 status.DefrostActive = res[3] != 0;
-                publish_state("status_defrost", status.DefrostActive ? "On" : "Off");
+                publish_state("status_defrost", status.DefrostActive);
                 break;
             case GetType::ERROR_STATE:
                 // 1 = refrigerant error code
@@ -100,9 +100,9 @@ namespace ecodan
                 status.In1ThermostatRequest = res[1] != 0;
                 status.In6ThermostatRequest = res[2] != 0;
                 status.In5ThermostatRequest = res[3] != 0;
-                publish_state("status_in1_request", status.In1ThermostatRequest ? "On" : "Off");
-                publish_state("status_in6_request", status.In6ThermostatRequest ? "On" : "Off");
-                publish_state("status_in5_request", status.In5ThermostatRequest ? "On" : "Off");
+                publish_state("status_in1_request", status.In1ThermostatRequest);
+                publish_state("status_in6_request", status.In6ThermostatRequest);
+                publish_state("status_in5_request", status.In5ThermostatRequest);
                 break;
             case GetType::ACTIVE_TIME:
                 status.Runtime = res.get_float24_v2(3);
@@ -118,10 +118,10 @@ namespace ecodan
                 status.ThreeWayValveActive = res[6] != 0;
                 status.WaterPump2Active = res[4] != 0;
                 status.ThreeWayValve2Active = res[7] != 0;                
-                publish_state("status_water_pump", status.WaterPumpActive ? "On" : "Off");
-                publish_state("status_three_way_valve", status.ThreeWayValveActive ? "On" : "Off");
-                publish_state("status_water_pump_2", status.WaterPump2Active ? "On" : "Off");
-                publish_state("status_three_way_valve_2", status.ThreeWayValve2Active ? "On" : "Off");                
+                publish_state("status_water_pump", status.WaterPumpActive);
+                publish_state("status_three_way_valve", status.ThreeWayValveActive);
+                publish_state("status_water_pump_2", status.WaterPump2Active);
+                publish_state("status_three_way_valve_2", status.ThreeWayValve2Active);                
                 //ESP_LOGI(TAG, res.debug_dump_packet().c_str());
                 break;                
             case GetType::FLOW_RATE:
@@ -131,8 +131,8 @@ namespace ecodan
                 status.ImmersionActive = res[5] != 0;
                 status.FlowRate = res[12];
                 publish_state("flow_rate", status.FlowRate);
-                publish_state("status_booster", status.BoosterActive ? "On" : "Off");
-                publish_state("status_immersion", status.ImmersionActive ? "On" : "Off");
+                publish_state("status_booster", status.BoosterActive);
+                publish_state("status_immersion", status.ImmersionActive);
                 status.update_output_power_estimation();
                 break;
             case GetType::MODE_FLAGS_A:
@@ -160,13 +160,13 @@ namespace ecodan
                 status.ProhibitHeatingZ2 = res[8] != 0;
                 status.ProhibitCoolingZ2 = res[9] != 0;
 
-                publish_state("status_dhw_forced", status.DhwForcedActive ? "On" : "Off");
-                publish_state("status_holiday", status.HolidayMode ? "On" : "Off");
-                publish_state("status_prohibit_dhw", status.ProhibitDhw ? "On" : "Off");
-                publish_state("status_prohibit_heating_z1", status.ProhibitHeatingZ1 ? "On" : "Off");
-                publish_state("status_prohibit_cool_z1", status.ProhibitCoolingZ1 ? "On" : "Off");
-                publish_state("status_prohibit_heating_z2", status.ProhibitHeatingZ2 ? "On" : "Off");
-                publish_state("status_prohibit_cool_z2", status.ProhibitCoolingZ2 ? "On" : "Off");
+                publish_state("status_dhw_forced", status.DhwForcedActive);
+                publish_state("status_holiday", status.HolidayMode);
+                publish_state("status_prohibit_dhw", status.ProhibitDhw);
+                publish_state("status_prohibit_heating_z1", status.ProhibitHeatingZ1);
+                publish_state("status_prohibit_cool_z1", status.ProhibitCoolingZ1);
+                publish_state("status_prohibit_heating_z2", status.ProhibitHeatingZ2);
+                publish_state("status_prohibit_cool_z2", status.ProhibitCoolingZ2);
                 break;
             case GetType::ENERGY_USAGE:
                 status.EnergyConsumedHeating = res.get_float24(4);

--- a/components/ecodan/response.cpp
+++ b/components/ecodan/response.cpp
@@ -19,7 +19,7 @@ namespace ecodan
                 break;
             case GetType::COMPRESSOR_FREQUENCY:
                 status.CompressorFrequency = res[1];
-                publish_state("compressor_frequency", status.CompressorFrequency);
+                publish_state("compressor_frequency", static_cast<float>(status.CompressorFrequency));
                 status.update_output_power_estimation();
                 break;
             case GetType::DHW_STATE:
@@ -28,12 +28,12 @@ namespace ecodan
                 //status.DhwForcedActive = res[7] != 0 && res[5] == 0; // byte 5 -> 7 is normal dhw, 0 - forced dhw
                 //publish_state("status_dhw_forced", status.DhwForcedActive ? "On" : "Off");
 
-                publish_state("heat_source", status.HeatSource);
+                publish_state("heat_source", static_cast<float>(status.HeatSource));
                 break;
             case GetType::HEATING_POWER:
                 status.OutputPower = res[6];
                 //status.BoosterActive = res[4] == 2;
-                publish_state("output_power", status.OutputPower);
+                publish_state("output_power", static_cast<float>(status.OutputPower));
                 publish_state("computed_output_power", status.ComputedOutputPower);
                 //publish_state("status_booster", status.BoosterActive ? "On" : "Off");
                 break;
@@ -130,7 +130,7 @@ namespace ecodan
                 status.BoosterActive = res[2] != 0;
                 status.ImmersionActive = res[5] != 0;
                 status.FlowRate = res[12];
-                publish_state("flow_rate", status.FlowRate);
+                publish_state("flow_rate", static_cast<float>(status.FlowRate));
                 publish_state("status_booster", status.BoosterActive);
                 publish_state("status_immersion", status.ImmersionActive);
                 status.update_output_power_estimation();
@@ -194,7 +194,7 @@ namespace ecodan
             case GetType::HARDWARE_CONFIGURATION:
                 // byte 6 = ftc, ft2b , ftc4, ftc5, ftc6
                 status.Controller = res[6];
-                publish_state("controller_version", status.Controller);
+                publish_state("controller_version", static_cast<float>(status.Controller));
                 break;
             default:
                 ESP_LOGI(TAG, "Unknown response type received on serial port: %u", static_cast<uint8_t>(res.payload_type<GetType>()));

--- a/components/ecodan/sensor.py
+++ b/components/ecodan/sensor.py
@@ -7,6 +7,7 @@ from esphome.const import (
     DEVICE_CLASS_FREQUENCY,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_VOLUME_FLOW_RATE,
     DEVICE_CLASS_WATER,
     ENTITY_CATEGORY_NONE,
     ENTITY_CATEGORY_DIAGNOSTIC,
@@ -131,8 +132,9 @@ CONFIG_SCHEMA = cv.Schema(
             state_class=STATE_CLASS_MEASUREMENT,
         ),        
         cv.Optional("flow_rate"): sensor.sensor_schema(
-            unit_of_measurement="l/m",
+            unit_of_measurement="L/m",
             icon="mdi:waves-arrow-right",
+            device_class=DEVICE_CLASS_VOLUME_FLOW_RATE,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional("cool_cop"): sensor.sensor_schema(

--- a/components/ecodan/text_sensor.py
+++ b/components/ecodan/text_sensor.py
@@ -15,98 +15,30 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_ECODAN_ID): cv.use_id(ECODAN),
         cv.Optional("controller_version_text"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
+            icon="mdi:new-box",
             entity_category=ENTITY_CATEGORY_NONE,
-        ),        
+        ),
         cv.Optional("heat_source_text"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
+            icon="mdi:fire",
             entity_category=ENTITY_CATEGORY_NONE,
-        ),        
-        cv.Optional("status_defrost"): text_sensor.text_sensor_schema(
-            icon="mdi:radiobox-blank",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),        
+        ),
         cv.Optional("status_dhw"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
+            icon="mdi:water-boiler",
             entity_category=ENTITY_CATEGORY_NONE,
-        ),              
-        cv.Optional("status_dhw_forced"): text_sensor.text_sensor_schema(
-            icon="mdi:radiobox-blank",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),        
+        ),
         cv.Optional("status_heating_cooling"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
+            icon="mdi:thermostat",
             entity_category=ENTITY_CATEGORY_NONE,
-        ),        
+        ),
         cv.Optional("status_power"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
+            icon="mdi:power",
             entity_category=ENTITY_CATEGORY_NONE,
-        ),        
+        ),
         cv.Optional("status_operation"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),        
-        cv.Optional("status_holiday"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),        
-        cv.Optional("status_booster"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ), 
-        cv.Optional("status_immersion"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),     
-        cv.Optional("status_in1_request"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ), 
-        cv.Optional("status_in6_request"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
+            icon="mdi:power",
             entity_category=ENTITY_CATEGORY_NONE,
         ),
-        cv.Optional("status_in5_request"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),              
-        cv.Optional("status_water_pump"): text_sensor.text_sensor_schema(
-            icon="mdi:radiobox-blank",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),
-        cv.Optional("status_three_way_valve"): text_sensor.text_sensor_schema(
-            icon="mdi:radiobox-blank",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),  
-        cv.Optional("status_water_pump_2"): text_sensor.text_sensor_schema(
-            icon="mdi:radiobox-blank",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),
-        cv.Optional("status_three_way_valve_2"): text_sensor.text_sensor_schema(
-            icon="mdi:radiobox-blank",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),                           
-        cv.Optional("status_prohibit_dhw"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),
-        cv.Optional("status_prohibit_heating_z1"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),        
-        cv.Optional("status_prohibit_cool_z1"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),        
-        cv.Optional("status_prohibit_heating_z2"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),        
-        cv.Optional("status_prohibit_cool_z2"): text_sensor.text_sensor_schema(
-            icon="mdi:alert",            
-            entity_category=ENTITY_CATEGORY_NONE,
-        ),        
-        
+
     }).extend(cv.COMPONENT_SCHEMA)
 
 async def to_code(config):

--- a/confs/base.yaml
+++ b/confs/base.yaml
@@ -103,8 +103,10 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: ${esp_ip}
+      icon: mdi:ip
     ssid:
       name: ${esp_sidd}
+      icon: mdi:wifi
 
   - platform: version
     name: ${esp_version}
@@ -116,6 +118,8 @@ text_sensor:
   - platform: template
     id: controller_version_text
     name: ${controller_version_text}
+    icon: mdi:new-box
+    entity_category: diagnostic
     lambda: |-
       int value = id(controller_version).state;
       switch (value) {
@@ -281,6 +285,7 @@ sensor:
     controller_version:
       id: controller_version
       internal: true
+      entity_category: diagnostic
     heat_source:
       id: heat_source
       internal: true          
@@ -377,6 +382,7 @@ sensor:
     unit_of_measurement: " %"
     entity_category: diagnostic
     device_class: ""
+    icon: mdi:wifi
 
   - platform: uptime
     name: ${uptime}

--- a/confs/base.yaml
+++ b/confs/base.yaml
@@ -147,9 +147,6 @@ text_sensor:
       }  
 
   - platform: ecodan
-    status_defrost:
-      id: status_defrost
-      name: ${status_defrost}
     status_dhw:
       id: status_dhw 
       name: ${status_dhw}
@@ -163,31 +160,6 @@ text_sensor:
       #           id: heatpump_select_dhw_mode
       #           option: !lambda "return id(status_dhw).state;"
 
-    status_dhw_forced:
-      name: ${status_dhw_forced}
-      id: status_dhw_forced
-      on_value:
-        if:
-          condition:
-            and:
-              - text_sensor.state:
-                  id: status_dhw_forced
-                  state: 'Off'
-              - switch.is_on: heatpump_switch_force_dhw
-          then:
-            - switch.turn_off:
-                id: heatpump_switch_force_dhw
-          else:
-            if:
-              condition:
-                and:
-                  - text_sensor.state:
-                      id: status_dhw_forced
-                      state: 'On'
-                  - switch.is_off: heatpump_switch_force_dhw
-              then:
-                - switch.turn_on:
-                    id: heatpump_switch_force_dhw
 
     status_heating_cooling:
       id: status_heating_cooling
@@ -231,55 +203,6 @@ text_sensor:
     status_operation:
       id: status_operation
       name: ${status_operation}
-    status_holiday:
-      id: status_holiday
-      name: ${status_holiday}
-      on_value:
-        if:
-          condition:
-            and:
-              - text_sensor.state:
-                  id: status_holiday
-                  state: 'Off'
-              - switch.is_on: heatpump_switch_holiday
-          then:
-            - switch.turn_off:
-                id: heatpump_switch_holiday
-          else:
-            if:
-              condition:
-                and:
-                  - text_sensor.state:
-                      id: status_holiday
-                      state: 'On'
-                  - switch.is_off: heatpump_switch_holiday
-              then:
-                - switch.turn_on:
-                    id: heatpump_switch_holiday      
-    status_booster:
-      id: status_booster
-      name: ${status_booster}
-    status_immersion:
-      id: status_immersion
-      name: ${status_immersion}
-    status_prohibit_dhw:
-      id: status_prohibit_dhw
-      name: ${status_prohibit_dhw}
-    status_water_pump:
-      id: status_water_pump
-      name: ${status_water_pump}
-    status_three_way_valve:
-      id: status_three_way_valve
-      name: ${status_three_way_valve}
-    status_in1_request:
-      id: status_in1_request
-      name: ${status_in1_request}
-    status_in6_request:
-      id: status_in6_request
-      name: ${status_in6_request}
-    status_in5_request:
-      id: status_in5_request
-      name: ${status_in5_request}
 sensor:
   - platform: ecodan
     controller_version:
@@ -399,3 +322,75 @@ sensor:
   - platform: internal_temperature
     name: ${internal_esp_temperature}
     entity_category: diagnostic
+
+binary_sensor:
+  - platform: ecodan
+    status_holiday:
+      id: status_holiday
+      name: ${status_holiday}
+      on_state:
+        if:
+          condition:
+            and:
+              - binary_sensor.is_off: status_holiday
+              - switch.is_on: heatpump_switch_holiday
+          then:
+            - switch.turn_off:
+                id: heatpump_switch_holiday
+          else:
+            if:
+              condition:
+                and:
+                  - binary_sensor.is_on: status_holiday
+                  - switch.is_off: heatpump_switch_holiday
+              then:
+                - switch.turn_on:
+                    id: heatpump_switch_holiday      
+    status_dhw_forced:
+      name: ${status_dhw_forced}
+      id: status_dhw_forced
+      on_state:
+        if:
+          condition:
+            and:
+              - binary_sensor.is_off: status_dhw_forced
+              - switch.is_on: heatpump_switch_force_dhw
+          then:
+            - switch.turn_off:
+                id: heatpump_switch_force_dhw
+          else:
+            if:
+              condition:
+                and:
+                  - binary_sensor.is_on: status_dhw_forced
+                  - switch.is_off: heatpump_switch_force_dhw
+              then:
+                - switch.turn_on:
+                    id: heatpump_switch_force_dhw
+    status_defrost:
+      id: status_defrost
+      name: ${status_defrost}
+    status_booster:
+      id: status_booster
+      name: ${status_booster}
+    status_immersion:
+      id: status_immersion
+      name: ${status_immersion}
+    status_prohibit_dhw:
+      id: status_prohibit_dhw
+      name: ${status_prohibit_dhw}
+    status_water_pump:
+      id: status_water_pump
+      name: ${status_water_pump}
+    status_three_way_valve:
+      id: status_three_way_valve
+      name: ${status_three_way_valve}
+    status_in1_request:
+      id: status_in1_request
+      name: ${status_in1_request}
+    status_in6_request:
+      id: status_in6_request
+      name: ${status_in6_request}
+    status_in5_request:
+      id: status_in5_request
+      name: ${status_in5_request}

--- a/confs/ecodan-labels-en.yaml
+++ b/confs/ecodan-labels-en.yaml
@@ -1,88 +1,88 @@
 substitutions:
-  status_three_way_valve: 3-way valve status
-  status_three_way_valve_2: 3-way valve 2 status
-  dhw_temp: DHW current temp
-  dhw_secondary_temp: DHW secondary temp
-  status_dhw_forced: DHW forced status
-  dhw_flow_temp_drop: DHW max temp drop
-  status_prohibit_dhw: DHW prohibit status
-  heatpump_number_set_dhw_temperature: DHW setpoint
-  dhw_flow_temp_target: DHW setpoint value
-  status_dhw: DHW status value
-  esp_ip: Esp IP
-  internal_esp_temperature: Esp Internal temperature
-  esp_sidd: Esp SSID
-  uptime: Esp Uptime
-  esp_version: Esp Version
-  restart_button: Esp restart
-  status_in1_request: In1 thermostat status
-  status_in6_request: In6 thermostat 2 status
-  status_in5_request: In5 outdoor thermostat status
-  heatpump_select_dhw_mode: Set DHW mode
+  status_three_way_valve: 3-way Valve Status
+  status_three_way_valve_2: 3-way Valve 2 Status
+  dhw_temp: DHW Current Temp
+  dhw_secondary_temp: DHW Secondary Temp
+  status_dhw_forced: DHW Forced Status
+  dhw_flow_temp_drop: DHW Max Temp Drop
+  status_prohibit_dhw: DHW Prohibit Status
+  heatpump_number_set_dhw_temperature: DHW Setpoint
+  dhw_flow_temp_target: DHW Setpoint Value
+  status_dhw: DHW Status Value
+  esp_ip: ESP IP
+  internal_esp_temperature: ESP Internal Temperature
+  esp_sidd: ESP SSID
+  uptime: ESP Uptime
+  esp_version: ESP Version
+  restart_button: ESP Restart
+  status_in1_request: In1 Thermostat Status
+  status_in6_request: In6 Thermostat 2 Status
+  status_in5_request: In5 Outdoor Thermostat Status
+  heatpump_select_dhw_mode: Set DHW Mode
   of: "Off"
   normal: Normal
   eco: Eco
-  version: ESP version
-  led_brightness: Set Led brightness
-  led_switch: Set Led switch
-  heatpump_switch_force_dhw: Set force dhw
-  heatpump_switch_power_mode: Set heatpump On/Off
-  heatpump_switch_holiday: Set holiday mode
+  version: ESP Version
+  led_brightness: Set LED Brightness
+  led_switch: Set LED Switch
+  heatpump_switch_force_dhw: Set Force DHW
+  heatpump_switch_power_mode: Set Heatpump On/Off
+  heatpump_switch_holiday: Set Holiday Mode
   wifi_signal_proc: WiFi Signal %
   wifi_signal_db: WiFi Signal dB
   heatpump_number_z1_set_flow_temperature: Zone 1 H/C setpoint
   z1_flow_temp_target: Zone 1 H/C setpoint value
   status_prohibit_cool_z1: Zone 1 prohibit cooling status
-  status_prohibit_heating_z1: Zone 1 prohibit heating status
-  heatpump_number_z1_set_room_temperature: Zone 1 room setpoint
-  z1_room_temp_target: Zone 1 room setpoint value
-  z1_room_temp: Zone 1 room temp
+  status_prohibit_heating_z1: Zone 1 Prohibit Heating Status
+  heatpump_number_z1_set_room_temperature: Zone 1 Room Setpoint
+  z1_room_temp_target: Zone 1 Room Setpoint Value
+  z1_room_temp: Zone 1 Room Temp
   heatpump_number_z2_set_flow_temperature: Zone 2 H/C setpoint
-  z2_flow_temp_target: Zone 2 H/C setpoint value
-  status_prohibit_cool_z2: Zone 2 prohibit cooling status
-  status_prohibit_heating_z2: Zone 2 prohibit heating status
-  heatpump_number_z2_set_room_temperature: Zone 2 room setpoint
-  z2_room_temp_target: Zone 2 room setpoint value
-  z2_room_temp: Zone 2 room temp
-  boiler_flow_temp: boiler flow temp
-  boiler_return_temp: boiler return temp
-  status_booster: booster heater status
-  compressor_frequency: compressor frequency
-  controller_version_text: controller version
-  cool_consumed: cool consumed
-  cool_cop: cool cop
-  cool_delivered: cool delivered
-  status_defrost: defrost state
-  dhw_consumed: dhw consumed
-  dhw_cop: dhw cop
-  dhw_delivered: dhw delivered
-  hp_feed_temp: feed temp
-  flow_rate: flow rate
-  heat_source_text: heat source
-  heatpump: heatpump
-  immersion_heater: immersion heater
-  booster_heater: booster heater
-  immersion_and_booster_heater: immersion and booster heater
-  boiler: boiler
-  heating_consumed: heating consumed
-  heating_cop: heating cop
-  heating_delivered: heating delivered
-  status_holiday: holiday status
-  status_immersion: immersion heater status
-  legionella_prevention_temp: legionella prevention temp
+  z2_flow_temp_target: Zone 2 H/C Setpoint Value
+  status_prohibit_cool_z2: Zone 2 Prohibit Cooling Status
+  status_prohibit_heating_z2: Zone 2 Prohibit Heating Status
+  heatpump_number_z2_set_room_temperature: Zone 2 Room Setpoint
+  z2_room_temp_target: Zone 2 Room Setpoint Value
+  z2_room_temp: Zone 2 Room Temp
+  boiler_flow_temp: Boiler Flow Temp
+  boiler_return_temp: Boiler Return Temp
+  status_booster: Booster Heater Status
+  compressor_frequency: Compressor Frequency
+  controller_version_text: Controller Version
+  cool_consumed: Cool Consumed
+  cool_cop: Cool COP
+  cool_delivered: Cool Delivered
+  status_defrost: Defrost State
+  dhw_consumed: DHW Consumed
+  dhw_cop: DHW COP
+  dhw_delivered: DHW Delivered
+  hp_feed_temp: Feed Temp
+  flow_rate: Flow Rate
+  heat_source_text: Heat Source
+  heatpump: Heatpump
+  immersion_heater: Immersion Heater
+  booster_heater: Booster Heater
+  immersion_and_booster_heater: Immersion and Booster Heater
+  boiler: Boiler
+  heating_consumed: Heating Consumed
+  heating_cop: Heating COP
+  heating_delivered: Heating Delivered
+  status_holiday: Holiday Status
+  status_immersion: Immersion Heater Status
+  legionella_prevention_temp: Legionella Prevention Temp
   heatpump_select_operating_mode: Operating mode
   heat_target_temperature: Heat Target Temperature
   heat_flow_temperature: Heat Flow Temperature
   heat_compensation_curve: Heat Compensation Curve
   cool_target_temperature: Cool Target Temperature
   cool_flow_temperature: Cool Flow Temperature
-  runtime: operating runtime
-  status_operation: operation status
-  output_power: output power
-  computed_output_power: estimated output power
-  outside_temp: outside temp
-  hp_refrigerant_temp: refrigerant liquid temp
-  hp_refrigerant_condensing_temp: refrigerant condensing temp
-  hp_return_temp: return temp
-  status_water_pump: water pump status
-  status_water_pump_2: water pump 2 status
+  runtime: Operating Runtime
+  status_operation: Operation Status
+  output_power: Output Power
+  computed_output_power: Estimated Output Power
+  outside_temp: Outside Temp
+  hp_refrigerant_temp: Refrigerant Liquid Temp
+  hp_refrigerant_condensing_temp: Refrigerant Condensing Temp
+  hp_return_temp: Return Temp
+  status_water_pump: Water Pump Status
+  status_water_pump_2: Water Pump 2 Status

--- a/confs/ecodan-labels-en.yaml
+++ b/confs/ecodan-labels-en.yaml
@@ -1,58 +1,58 @@
 substitutions:
-  status_three_way_valve: 3-way Valve Status
-  status_three_way_valve_2: 3-way Valve 2 Status
+  status_three_way_valve: 3-way Valve
+  status_three_way_valve_2: 3-way Valve 2
   dhw_temp: DHW Current Temp
   dhw_secondary_temp: DHW Secondary Temp
-  status_dhw_forced: DHW Forced Status
+  status_dhw_forced: DHW Forced
   dhw_flow_temp_drop: DHW Max Temp Drop
-  status_prohibit_dhw: DHW Prohibit Status
+  status_prohibit_dhw: DHW Prohibit
   heatpump_number_set_dhw_temperature: DHW Setpoint
   dhw_flow_temp_target: DHW Setpoint Value
-  status_dhw: DHW Status Value
+  status_dhw: DHW
   esp_ip: ESP IP
   internal_esp_temperature: ESP Internal Temperature
   esp_sidd: ESP SSID
   uptime: ESP Uptime
   esp_version: ESP Version
   restart_button: ESP Restart
-  status_in1_request: In1 Thermostat Status
-  status_in6_request: In6 Thermostat 2 Status
-  status_in5_request: In5 Outdoor Thermostat Status
-  heatpump_select_dhw_mode: Set DHW Mode
+  status_in1_request: In1 Thermostat
+  status_in6_request: In6 Thermostat 2
+  status_in5_request: In5 Outdoor Thermostat
+  heatpump_select_dhw_mode: DHW Mode
   of: "Off"
   normal: Normal
   eco: Eco
   version: ESP Version
-  led_brightness: Set LED Brightness
-  led_switch: Set LED Switch
-  heatpump_switch_force_dhw: Set Force DHW
-  heatpump_switch_power_mode: Set Heatpump On/Off
-  heatpump_switch_holiday: Set Holiday Mode
+  led_brightness: LED Brightness
+  led_switch: LED
+  heatpump_switch_force_dhw: Force DHW
+  heatpump_switch_power_mode: Heatpump
+  heatpump_switch_holiday: Holiday Mode
   wifi_signal_proc: WiFi Signal %
   wifi_signal_db: WiFi Signal dB
-  heatpump_number_z1_set_flow_temperature: Zone 1 H/C setpoint
-  z1_flow_temp_target: Zone 1 H/C setpoint value
-  status_prohibit_cool_z1: Zone 1 prohibit cooling status
-  status_prohibit_heating_z1: Zone 1 Prohibit Heating Status
+  heatpump_number_z1_set_flow_temperature: Zone 1 H/C Setpoint
+  z1_flow_temp_target: Zone 1 H/C Setpoint Value
+  status_prohibit_cool_z1: Zone 1 Prohibit Cooling Status
+  status_prohibit_heating_z1: Zone 1 Prohibit Heating
   heatpump_number_z1_set_room_temperature: Zone 1 Room Setpoint
   z1_room_temp_target: Zone 1 Room Setpoint Value
   z1_room_temp: Zone 1 Room Temp
   heatpump_number_z2_set_flow_temperature: Zone 2 H/C setpoint
   z2_flow_temp_target: Zone 2 H/C Setpoint Value
-  status_prohibit_cool_z2: Zone 2 Prohibit Cooling Status
-  status_prohibit_heating_z2: Zone 2 Prohibit Heating Status
+  status_prohibit_cool_z2: Zone 2 Prohibit Cooling
+  status_prohibit_heating_z2: Zone 2 Prohibit Heating
   heatpump_number_z2_set_room_temperature: Zone 2 Room Setpoint
   z2_room_temp_target: Zone 2 Room Setpoint Value
   z2_room_temp: Zone 2 Room Temp
   boiler_flow_temp: Boiler Flow Temp
   boiler_return_temp: Boiler Return Temp
-  status_booster: Booster Heater Status
+  status_booster: Booster Heater
   compressor_frequency: Compressor Frequency
   controller_version_text: Controller Version
   cool_consumed: Cool Consumed
   cool_cop: Cool COP
   cool_delivered: Cool Delivered
-  status_defrost: Defrost State
+  status_defrost: Defrost
   dhw_consumed: DHW Consumed
   dhw_cop: DHW COP
   dhw_delivered: DHW Delivered
@@ -67,8 +67,8 @@ substitutions:
   heating_consumed: Heating Consumed
   heating_cop: Heating COP
   heating_delivered: Heating Delivered
-  status_holiday: Holiday Status
-  status_immersion: Immersion Heater Status
+  status_holiday: Holiday Mode
+  status_immersion: Immersion Heater
   legionella_prevention_temp: Legionella Prevention Temp
   heatpump_select_operating_mode: Operating mode
   heat_target_temperature: Heat Target Temperature
@@ -77,7 +77,7 @@ substitutions:
   cool_target_temperature: Cool Target Temperature
   cool_flow_temperature: Cool Flow Temperature
   runtime: Operating Runtime
-  status_operation: Operation Status
+  status_operation: Operation Mode
   output_power: Output Power
   computed_output_power: Estimated Output Power
   outside_temp: Outside Temp

--- a/confs/zone1.yaml
+++ b/confs/zone1.yaml
@@ -1,4 +1,4 @@
-text_sensor:
+binary_sensor:
   - platform: ecodan
     status_prohibit_heating_z1:
       id: status_prohibit_heating_z1

--- a/ecodan-esphome.yaml
+++ b/ecodan-esphome.yaml
@@ -73,6 +73,7 @@ logger:
     esp32.preferences: DEBUG
     sensor: DEBUG
     text_sensor: DEBUG
+    binary_sensor: DEBUG
     switch: DEBUG
     button: DEBUG
     number: DEBUG


### PR DESCRIPTION
This is not finished yet, I just wanted your opinion on this route.

Things should use the appropriate HA platform (light, binary_sensor, climate, etc). The binary sensors are pretty easy, and come with nice default states like "running / not running" for pumps. The light platform will be pretty easy to do for the LED but not a priority.

I feel that the names are a bit verbose. There is context to these things, so a switch doesn't need the word "set", and a sensor doesn't need the word "value" or "status". Also I think it fits more with the HA theme if the names are titlecased. All of this could be changed by the user, of course, so it's not really important. Happy to take your view.

I also added a bunch of icons. Again, this might be your preference, so there is a bit more to do but I want your opinion first...

Thanks!