### PR TITLE
Adjust computed output power for Glycol in Water

### DIFF
--- a/components/ecodan/status.h
+++ b/components/ecodan/status.h
@@ -121,7 +121,7 @@ namespace ecodan
 
         void update_output_power_estimation() {
             if (CompressorFrequency > 0 && FlowRate > 0)  {
-                ComputedOutputPower = FlowRate/60.0 * abs(HpFeedTemperature - HpReturnTemperature) * 4.18f;
+                ComputedOutputPower = FlowRate/60.0 * abs(HpFeedTemperature - HpReturnTemperature) * 3.65f;
             }
             else {
                 ComputedOutputPower = 0.0f;


### PR DESCRIPTION
Suggested adjustment to account for heat capacity reduction due to Glycol as per [https://detector-cooling.web.cern.ch/data/Table%208-3-1.htm](this)