### PR TITLE
Change RX pin to GPIO3 for wroom-nodemcu ESP32.yaml

### DIFF
--- a/confs/esp32-wroom-nodemcu.yaml
+++ b/confs/esp32-wroom-nodemcu.yaml
@@ -10,7 +10,7 @@ esp32:
 uart:
   id: uart_ecodan
   rx_pin:
-    number: GPIO2
+    number: GPIO3
     mode:
       input: true
       pullup: true


### PR DESCRIPTION
Original ESP32.yaml defines:
 - RX to GPIO2
 - TX to GPIO1

WROOM NodeMCU board has:
 - RX at GPIO3
 - TX same at GPIO1