### PR TITLE
Outside temperature filtering

### DIFF
--- a/components/ecodan/climate.cpp
+++ b/components/ecodan/climate.cpp
@@ -50,15 +50,23 @@ namespace ecodan
                 case ecodan::Status::HpMode::HEAT_FLOW_TEMP:
                 case ecodan::Status::HpMode::HEAT_COMPENSATION_CURVE:
                     if (this->mode != climate::ClimateMode::CLIMATE_MODE_HEAT && allow_refresh) {
-                        this->mode = climate::ClimateMode::CLIMATE_MODE_HEAT;
-                        should_publish = true;
+                        if (this->climate_zone_identifier == ClimateZoneIdentifier::SINGLE_ZONE
+                            || static_cast<uint8_t>(ClimateZoneIdentifier::MULTI_ZONE_BOTH) == status.MultiZoneStatus
+                            || static_cast<uint8_t>(this->climate_zone_identifier) == status.MultiZoneStatus) {
+                            this->mode = climate::ClimateMode::CLIMATE_MODE_HEAT;
+                            should_publish = true;
+                        }
                     }
                 break;
                 case ecodan::Status::HpMode::COOL_ROOM_TEMP:
                 case ecodan::Status::HpMode::COOL_FLOW_TEMP:
                     if (this->mode != climate::ClimateMode::CLIMATE_MODE_COOL && allow_refresh) {
-                        this->mode = climate::ClimateMode::CLIMATE_MODE_COOL;
-                        should_publish = true;
+                        if (this->climate_zone_identifier == ClimateZoneIdentifier::SINGLE_ZONE
+                            || static_cast<uint8_t>(ClimateZoneIdentifier::MULTI_ZONE_BOTH) == status.MultiZoneStatus
+                            || static_cast<uint8_t>(this->climate_zone_identifier) == status.MultiZoneStatus) {
+                            this->mode = climate::ClimateMode::CLIMATE_MODE_COOL;
+                            should_publish = true;
+                        }
                     } 
                 break;                    
             case ecodan::Status::HpMode::OFF:

--- a/components/ecodan/climate.py
+++ b/components/ecodan/climate.py
@@ -19,6 +19,7 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Required("target_temp_func"): cv.string,
                 cv.Required("get_target_temp_func"): cv.string,
                 cv.Optional("current_temp_func"): cv.string,
+                cv.Optional("zone_identifier"): cv.uint8_t,
             }).extend(cv.polling_component_schema('100ms')),
         cv.Optional("heatpump_climate_room_z1"): climate.CLIMATE_SCHEMA.extend(
             {
@@ -27,6 +28,7 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Required("target_temp_func"): cv.string,
                 cv.Required("get_target_temp_func"): cv.string,
                 cv.Optional("current_temp_func"): cv.string,
+                cv.Optional("zone_identifier"): cv.uint8_t,
                 cv.Optional("thermostat_climate_mode"): cv.boolean,
             }).extend(cv.polling_component_schema('100ms')),            
         cv.Optional("heatpump_climate_z2"): climate.CLIMATE_SCHEMA.extend(
@@ -36,6 +38,7 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Required("target_temp_func"): cv.string,
                 cv.Required("get_target_temp_func"): cv.string,
                 cv.Optional("current_temp_func"): cv.string,
+                cv.Optional("zone_identifier"): cv.uint8_t,
             }).extend(cv.polling_component_schema('100ms')),
         cv.Optional("heatpump_climate_room_z2"): climate.CLIMATE_SCHEMA.extend(
             {
@@ -44,6 +47,7 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Required("target_temp_func"): cv.string,
                 cv.Required("get_target_temp_func"): cv.string,
                 cv.Optional("current_temp_func"): cv.string,
+                cv.Optional("zone_identifier"): cv.uint8_t,
                 cv.Optional("thermostat_climate_mode"): cv.boolean,
             }).extend(cv.polling_component_schema('100ms')),     
         cv.Optional("heatpump_climate_dhw"): climate.CLIMATE_SCHEMA.extend(
@@ -70,12 +74,15 @@ async def to_code(config):
             cg.add(inst.set_status(cg.RawExpression(f'[=](void) -> const ecodan::Status& {{ {conf["get_status_func"]} }}')))
             cg.add(inst.set_target_temp_func(cg.RawExpression(f'[=](float x){{ {conf["target_temp_func"]} }}')))
             cg.add(inst.set_get_target_temp_func(cg.RawExpression(f'[=](void) -> float {{ {conf["get_target_temp_func"]} }}')))
-            
+
             if "current_temp_func" in conf:
                 cg.add(inst.set_get_current_temp_func(cg.RawExpression(f'[=](void) -> float {{ {conf["current_temp_func"]} }}')))
             if "dhw_climate_mode" in conf:
                 cg.add(inst.set_dhw_climate_mode(True))
             if "thermostat_climate_mode" in conf:
-                cg.add(inst.set_thermostat_climate_mode(True))            
+                cg.add(inst.set_thermostat_climate_mode(True))
+            if "zone_identifier" in conf:
+                cg.add(inst.set_zone_identifier(conf["zone_identifier"]))
+
             await cg.register_component(inst, conf)
             await climate.register_climate(inst, conf)

--- a/components/ecodan/ecodan.h
+++ b/components/ecodan/ecodan.h
@@ -116,6 +116,7 @@ namespace ecodan
         void set_status(std::function<const ecodan::Status& (void)> get_status_func) { get_status = get_status_func; };
         void set_dhw_climate_mode(bool mode) { this->dhw_climate_mode = mode; }
         void set_thermostat_climate_mode(bool mode) { this->thermostat_climate_mode = mode; }
+        void set_zone_identifier(uint8_t zone_identifier) { this->climate_zone_identifier = static_cast<ClimateZoneIdentifier>(zone_identifier); }
     private:
         std::function<void(float)> set_target_temp = nullptr;
         std::function<float(void)> get_current_temp = nullptr;
@@ -123,6 +124,7 @@ namespace ecodan
         std::function<const ecodan::Status& (void)> get_status = nullptr;
         bool dhw_climate_mode = false;
         bool thermostat_climate_mode = false;
+        ClimateZoneIdentifier climate_zone_identifier = ClimateZoneIdentifier::SINGLE_ZONE;
 
         void refresh();
         void validate_target_temperature();

--- a/components/ecodan/proto.h
+++ b/components/ecodan/proto.h
@@ -4,6 +4,14 @@
 namespace esphome {
 namespace ecodan 
 {
+    enum class ClimateZoneIdentifier 
+    {
+        SINGLE_ZONE = 0,
+        MULTI_ZONE_BOTH = 1,
+        MULTI_ZONE_1 = 2,
+        MULTI_ZONE_2 = 3  
+    };
+
     // https://github.com/m000c400/Mitsubishi-CN105-Protocol-Decode
     enum class MsgType : uint8_t
     {

--- a/components/ecodan/response.cpp
+++ b/components/ecodan/response.cpp
@@ -122,7 +122,11 @@ namespace ecodan
                 publish_state("z2_room_temp", status.Zone2RoomTemperature);
                 publish_state("outside_temp", status.OutsideTemperature);
                 publish_state("hp_refrigerant_temp", status.HpRefrigerantLiquidTemperature); 
-                publish_state("hp_refrigerant_condensing_temp", status.HpRefrigerantCondensingTemperature);                
+                publish_state("hp_refrigerant_condensing_temp", status.HpRefrigerantCondensingTemperature);  
+                if (!status.DefrostActive)
+                {
+                    publish_state("outside_temp_filtered", status.OutsideTemperature);
+                }              
                 break;
             case GetType::TEMPERATURE_STATE_A:
                 status.HpFeedTemperature = res.get_float16(1);

--- a/components/ecodan/response.cpp
+++ b/components/ecodan/response.cpp
@@ -134,7 +134,7 @@ namespace ecodan
 
                 //freeze outside temp during defrost and wait 5 min to cool down
                 std::chrono::duration<double> elapsed_seconds = std::chrono::system_clock::now() - status.DefrostLastEndTime;
-                if (!status.DefrostActive && elapsed_seconds > 5 * 60)
+                if (!status.DefrostActive && elapsed_seconds.count() > 5 * 60)
                 {
                     publish_state("outside_temp_filtered", status.OutsideTemperature);
                 }              

--- a/components/ecodan/response.cpp
+++ b/components/ecodan/response.cpp
@@ -54,6 +54,7 @@ namespace ecodan
                 }
                 break;               
             case GetType::DEFROST_STATE:
+            {
                 bool defrostActiveNew = res[3] != 0; 
                 if (!defrostActiveNew && status.DefrostActive)
                 {
@@ -62,6 +63,7 @@ namespace ecodan
                 status.DefrostActive = defrostActiveNew;
                 publish_state("status_defrost", status.DefrostActive);
                 break;
+            }
             case GetType::ERROR_STATE:
                 // 1 = refrigerant error code
                 // 2+3 = fault code, [2]*100+[3]
@@ -116,6 +118,7 @@ namespace ecodan
 
                 break;
             case GetType::SH_TEMPERATURE_STATE:
+            {
                 // 0xF0 seems to be a sentinel value for "not reported in the current system"
                 status.Zone1RoomTemperature = res[1] != 0xF0 ? res.get_float16(1) : 0.0f;
                 status.Zone2RoomTemperature = res[3] != 0xF0 ? res.get_float16(3) : 0.0f;
@@ -136,6 +139,7 @@ namespace ecodan
                     publish_state("outside_temp_filtered", status.OutsideTemperature);
                 }              
                 break;
+            }
             case GetType::TEMPERATURE_STATE_A:
                 status.HpFeedTemperature = res.get_float16(1);
                 status.HpReturnTemperature = res.get_float16(4);

--- a/components/ecodan/response.cpp
+++ b/components/ecodan/response.cpp
@@ -128,7 +128,7 @@ namespace ecodan
 
                 publish_state("z1_room_temp", status.Zone1RoomTemperature);
                 publish_state("z2_room_temp", status.Zone2RoomTemperature);
-                publish_state("outside_temp", status.OutsideTemperature);
+                publish_state("outside_temp_raw", status.OutsideTemperature);
                 publish_state("hp_refrigerant_temp", status.HpRefrigerantLiquidTemperature); 
                 publish_state("hp_refrigerant_condensing_temp", status.HpRefrigerantCondensingTemperature);  
 
@@ -136,7 +136,7 @@ namespace ecodan
                 std::chrono::duration<double> elapsed_seconds = std::chrono::system_clock::now() - status.DefrostLastEndTime;
                 if (!status.DefrostActive && elapsed_seconds.count() > 5 * 60)
                 {
-                    publish_state("outside_temp_filtered", status.OutsideTemperature);
+                    publish_state("outside_temp", status.OutsideTemperature);
                 }              
                 break;
             }

--- a/components/ecodan/sensor.py
+++ b/components/ecodan/sensor.py
@@ -54,7 +54,7 @@ CONFIG_SCHEMA = cv.Schema(
             device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
-        cv.Optional("outside_temp_filtered"): sensor.sensor_schema(
+        cv.Optional("outside_temp_raw"): sensor.sensor_schema(
             unit_of_measurement=UNIT_CELSIUS,
             icon="mdi:sun-thermometer",
             accuracy_decimals=0,

--- a/components/ecodan/sensor.py
+++ b/components/ecodan/sensor.py
@@ -54,6 +54,13 @@ CONFIG_SCHEMA = cv.Schema(
             device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
+        cv.Optional("outside_temp_filtered"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:sun-thermometer",
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
         cv.Optional("hp_feed_temp"): sensor.sensor_schema(
             unit_of_measurement=UNIT_CELSIUS,
             icon="mdi:coolant-temperature",

--- a/components/ecodan/status.h
+++ b/components/ecodan/status.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <chrono>
 
 namespace esphome {
 namespace ecodan 
@@ -10,6 +11,7 @@ namespace ecodan
         bool Initialized = false;
 
         bool DefrostActive;
+        std::chrono::time_point<std::chrono::system_clock> DefrostLastEndTime;
         bool DhwForcedActive;        
         bool BoosterActive;
         bool ImmersionActive;

--- a/confs/base.yaml
+++ b/confs/base.yaml
@@ -207,6 +207,9 @@ sensor:
     outside_temp:
       id: outside_temp
       name: ${outside_temp}
+    outside_temp_filtered:
+      id: outside_temp_filtered
+      name: ${outside_temp_filtered}
     hp_feed_temp:
       id: hp_feed_temp
       name: ${hp_feed_temp}

--- a/confs/base.yaml
+++ b/confs/base.yaml
@@ -207,9 +207,9 @@ sensor:
     outside_temp:
       id: outside_temp
       name: ${outside_temp}
-    outside_temp_filtered:
-      id: outside_temp_filtered
-      name: ${outside_temp_filtered}
+    outside_temp_raw:
+      id: outside_temp_raw
+      name: ${outside_temp_raw}
     hp_feed_temp:
       id: hp_feed_temp
       name: ${hp_feed_temp}

--- a/confs/ecodan-labels-en.yaml
+++ b/confs/ecodan-labels-en.yaml
@@ -93,7 +93,7 @@ substitutions:
   output_power: Output Power
   computed_output_power: Estimated Output Power
   outside_temp: Outside Temp
-  outside_temp_filtered: Outside Temp Filt.
+  outside_temp_raw: Outside Temp Raw
   hp_refrigerant_temp: Refrigerant Liquid Temp
   hp_refrigerant_condensing_temp: Refrigerant Condensing Temp
   hp_return_temp: Return Temp

--- a/confs/ecodan-labels-en.yaml
+++ b/confs/ecodan-labels-en.yaml
@@ -93,6 +93,7 @@ substitutions:
   output_power: Output Power
   computed_output_power: Estimated Output Power
   outside_temp: Outside Temp
+  outside_temp_filtered: Outside Temp Filt.
   hp_refrigerant_temp: Refrigerant Liquid Temp
   hp_refrigerant_condensing_temp: Refrigerant Condensing Temp
   hp_return_temp: Return Temp

--- a/confs/ecodan-labels-fr.yaml
+++ b/confs/ecodan-labels-fr.yaml
@@ -93,7 +93,7 @@ substitutions:
   output_power: Puissance de sortie
   computed_output_power: Puissance de sortie estimée
   outside_temp: Temp Ext
-  outside_temp_filtered: Temp Ext Filt.
+  outside_temp_raw: Temp Ext Brute
   hp_refrigerant_temp: Temp Liquide Réfrigérant
   hp_refrigerant_condensing_temp: Temp Condensation Liquide Réfrigérant
   hp_return_temp: Temp retour

--- a/confs/ecodan-labels-fr.yaml
+++ b/confs/ecodan-labels-fr.yaml
@@ -93,6 +93,7 @@ substitutions:
   output_power: Puissance de sortie
   computed_output_power: Puissance de sortie estimée
   outside_temp: Temp Ext
+  outside_temp_filtered: Temp Ext Filt.
   hp_refrigerant_temp: Temp Liquide Réfrigérant
   hp_refrigerant_condensing_temp: Temp Condensation Liquide Réfrigérant
   hp_return_temp: Temp retour

--- a/confs/ecodan-labels-it.yaml
+++ b/confs/ecodan-labels-it.yaml
@@ -93,7 +93,7 @@ substitutions:
   output_power: En. Prod.
   computed_output_power: Stima En. Prod.
   outside_temp: T. Esterna
-  outside_temp_filtered: T. Esterna Filt.
+  outside_temp_raw: T. Esterna Cruda
   hp_refrigerant_temp: T. Mandata Liq. Refr.
   hp_refrigerant_condensing_temp: T. Cond. Liq. Refr.
   hp_return_temp: T. Ritorno Liq. Refr.

--- a/confs/ecodan-labels-it.yaml
+++ b/confs/ecodan-labels-it.yaml
@@ -93,6 +93,7 @@ substitutions:
   output_power: En. Prod.
   computed_output_power: Stima En. Prod.
   outside_temp: T. Esterna
+  outside_temp_filtered: T. Esterna Filt.
   hp_refrigerant_temp: T. Mandata Liq. Refr.
   hp_refrigerant_condensing_temp: T. Cond. Liq. Refr.
   hp_return_temp: T. Ritorno Liq. Refr.

--- a/confs/ecodan-labels-nl.yaml
+++ b/confs/ecodan-labels-nl.yaml
@@ -93,6 +93,7 @@ substitutions:
   output_power: Afgegeven vermogen
   computed_output_power: Geschatte afgegeven vermogen
   outside_temp: Buiten temp
+  outside_temp_filtered: Buiten temp Filt.
   hp_refrigerant_temp: Koelmiddel temp
   hp_refrigerant_condensing_temp: Koelmiddel condensatie temp
   hp_return_temp: Retour temp

--- a/confs/ecodan-labels-nl.yaml
+++ b/confs/ecodan-labels-nl.yaml
@@ -93,7 +93,7 @@ substitutions:
   output_power: Afgegeven vermogen
   computed_output_power: Geschatte afgegeven vermogen
   outside_temp: Buiten temp
-  outside_temp_filtered: Buiten temp Filt.
+  outside_temp_raw: Buiten temp rauw
   hp_refrigerant_temp: Koelmiddel temp
   hp_refrigerant_condensing_temp: Koelmiddel condensatie temp
   hp_return_temp: Retour temp

--- a/confs/zone1.yaml
+++ b/confs/zone1.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  zone_identifier_z1: "0"
+
 binary_sensor:
   - platform: ecodan
     status_prohibit_heating_z1:
@@ -15,6 +18,7 @@ climate:
     heatpump_climate_z1:
       name: ${heatpump_climate_z1}
       id: heatpump_climate_z1
+      zone_identifier: ${zone_identifier_z1}
       get_status_func: |-
         return id(ecodan_instance).get_status();
       get_target_temp_func: |-
@@ -68,6 +72,7 @@ climate:
       name: ${heatpump_climate_room_z1}
       id: heatpump_climate_room_z1
       thermostat_climate_mode: true
+      zone_identifier: ${zone_identifier_z1}
       get_status_func: |-
         return id(ecodan_instance).get_status();
       get_target_temp_func: |-

--- a/confs/zone2.yaml
+++ b/confs/zone2.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  zone_identifier_z1: "2"
+
 binary_sensor:
   - platform: ecodan
     status_prohibit_heating_z2:
@@ -18,6 +21,7 @@ climate:
     heatpump_climate_z2:
       name: ${heatpump_climate_z2}
       id: heatpump_climate_z2
+      zone_identifier: 3
       get_status_func: |-
         return id(ecodan_instance).get_status();
       get_target_temp_func: |-
@@ -71,6 +75,7 @@ climate:
       name: ${heatpump_climate_room_z2}
       id: heatpump_climate_room_z2
       thermostat_climate_mode: true
+      zone_identifier: 3
       get_status_func: |-
         return id(ecodan_instance).get_status();
       get_target_temp_func: |-


### PR DESCRIPTION
Because Ecodan HPs have rather unfortunate outside temperature sensor placement reading gets affected by defrost:
![image](https://github.com/user-attachments/assets/14e93d58-e600-467d-a459-8c11fcb29264)
That is why I implemented some filtering: no update of temp sensor during defrost. Well that was not enough so I needed to add additional 5 minute freeze after defrost finishes. 
Because I think really nobody wants these spikes I did this directly on existing sensor and I added new one called `raw` which uses direct values. End result:
![image](https://github.com/user-attachments/assets/e98a4ec0-1126-460c-8a0e-eff609553db0)
