### PR TITLE
typo  daily_computed_output_power

### DIFF
--- a/confs/ecodan-labels-nl.yaml
+++ b/confs/ecodan-labels-nl.yaml
@@ -92,7 +92,7 @@ substitutions:
   status_operation: Status Bedrijf
   output_power: Afgegeven vermogen
   computed_output_power: Geschatte afgegeven vermogen
-  computed_output_power: Geschatte afgegeven vermogen (Per dag)
+  daily_computed_output_power: Geschatte afgegeven vermogen (Per dag)
   outside_temp: Buiten temp
   hp_refrigerant_temp: Koelmiddel temp
   hp_refrigerant_condensing_temp: Koelmiddel condensatie temp

--- a/confs/ecodan-labels-nl.yaml
+++ b/confs/ecodan-labels-nl.yaml
@@ -111,4 +111,3 @@ substitutions:
   status_multi_zone_zone2: Z2 actief
   fault_code_text: Fout code
   refrigerant_error_code_text: Koelmiddel fout code
-  status_mrc: MRC Status

--- a/confs/ecodan-labels-nl.yaml
+++ b/confs/ecodan-labels-nl.yaml
@@ -111,3 +111,4 @@ substitutions:
   status_multi_zone_zone2: Z2 actief
   fault_code_text: Fout code
   refrigerant_error_code_text: Koelmiddel fout code
+  status_mrc: MRC Status

--- a/proxy_connecting.md
+++ b/proxy_connecting.md
@@ -65,6 +65,7 @@ packages:
             #confs/ecodan-labels-nl.yaml,
             #confs/ecodan-labels-it.yaml,
             #confs/ecodan-labels-fr.yaml,
+            #confs/ecodan-labels-es.yaml
             confs/server-control.yaml,
             #confs/debug.yaml,
             ## enable this to monitor WiFi status with ESP in-built LED


### PR DESCRIPTION
There is a double substitution name in the dutch language file