### PR TITLE
Adds query of service request codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ packages:
     ref: main
     refresh: always
     files: [ 
-            confs/base.yaml,        # required
-            confs/esp32s3.yaml, # confs/esp32.yaml, for regular board
+            confs/base.yaml,            # required
+            confs/request-codes.yaml,   # disable if your unit does not support request codes (service menu)
+            confs/esp32s3.yaml,         # confs/esp32.yaml, for regular board
             confs/zone1.yaml,
             ## enable if you want to use zone 2
             #confs/zone2.yaml,

--- a/components/ecodan/commands.cpp
+++ b/components/ecodan/commands.cpp
@@ -237,13 +237,19 @@ namespace ecodan
         std::chrono::time_point<std::chrono::steady_clock> LastAttempt{};
     };
 
-    #define MAX_SERVICE_CODE_CMD_SIZE 4
+    #define MAX_SERVICE_CODE_CMD_SIZE 9
     ServiceCodeRuntime serviceCodeCmdQueue[MAX_SERVICE_CODE_CMD_SIZE] = {
         ServiceCodeRuntime{Status::REQUEST_CODE::COMPRESSOR_STARTS, 30*60, std::chrono::steady_clock::now() - std::chrono::seconds(60*60)},
         ServiceCodeRuntime{Status::REQUEST_CODE::TH4_DISCHARGE_TEMP, 0, std::chrono::steady_clock::time_point{}},
         ServiceCodeRuntime{Status::REQUEST_CODE::TH3_LIQUID_PIPE1_TEMP, 0, std::chrono::steady_clock::time_point{}},
+        ServiceCodeRuntime{Status::REQUEST_CODE::TH6_2_PHASE_PIPE_TEMP, 0, std::chrono::steady_clock::time_point{}},
+        ServiceCodeRuntime{Status::REQUEST_CODE::TH32_SUCTION_PIPE_TEMP, 0, std::chrono::steady_clock::time_point{}},
+        ServiceCodeRuntime{Status::REQUEST_CODE::TH8_HEAT_SINK_TEMP, 0, std::chrono::steady_clock::time_point{}},
+        ServiceCodeRuntime{Status::REQUEST_CODE::DISCHARGE_SUPERHEAT, 0, std::chrono::steady_clock::time_point{}},
+        ServiceCodeRuntime{Status::REQUEST_CODE::SUB_COOL, 0, std::chrono::steady_clock::time_point{}},
         ServiceCodeRuntime{Status::REQUEST_CODE::FAN_SPEED, 0, std::chrono::steady_clock::time_point{}}
     };
+
 
     bool EcodanHeatpump::dispatch_next_status_cmd()
     {

--- a/components/ecodan/commands.cpp
+++ b/components/ecodan/commands.cpp
@@ -237,7 +237,7 @@ namespace ecodan
         std::chrono::time_point<std::chrono::steady_clock> LastAttempt{};
     };
 
-    #define MAX_SERVICE_CODE_CMD_SIZE 6
+    #define MAX_SERVICE_CODE_CMD_SIZE 4
     ServiceCodeRuntime serviceCodeCmdQueue[MAX_SERVICE_CODE_CMD_SIZE] = {
         ServiceCodeRuntime{Status::REQUEST_CODE::COMPRESSOR_STARTS, 30*60, std::chrono::steady_clock::now() - std::chrono::seconds(60*60)},
         ServiceCodeRuntime{Status::REQUEST_CODE::TH4_DISCHARGE_TEMP, 0, std::chrono::steady_clock::time_point{}},
@@ -245,8 +245,8 @@ namespace ecodan
         //ServiceCodeRuntime{Status::REQUEST_CODE::TH6_2_PHASE_PIPE_TEMP, 0, std::chrono::steady_clock::time_point{}},
         //ServiceCodeRuntime{Status::REQUEST_CODE::TH32_SUCTION_PIPE_TEMP, 0, std::chrono::steady_clock::time_point{}},
         //ServiceCodeRuntime{Status::REQUEST_CODE::TH8_HEAT_SINK_TEMP, 0, std::chrono::steady_clock::time_point{}},
-        ServiceCodeRuntime{Status::REQUEST_CODE::DISCHARGE_SUPERHEAT, 0, std::chrono::steady_clock::time_point{}},
-        ServiceCodeRuntime{Status::REQUEST_CODE::SUB_COOL, 0, std::chrono::steady_clock::time_point{}},
+        //ServiceCodeRuntime{Status::REQUEST_CODE::DISCHARGE_SUPERHEAT, 0, std::chrono::steady_clock::time_point{}},
+        //ServiceCodeRuntime{Status::REQUEST_CODE::SUB_COOL, 0, std::chrono::steady_clock::time_point{}},
         ServiceCodeRuntime{Status::REQUEST_CODE::FAN_SPEED, 0, std::chrono::steady_clock::time_point{}}
     };
 

--- a/components/ecodan/commands.cpp
+++ b/components/ecodan/commands.cpp
@@ -237,19 +237,18 @@ namespace ecodan
         std::chrono::time_point<std::chrono::steady_clock> LastAttempt{};
     };
 
-    #define MAX_SERVICE_CODE_CMD_SIZE 9
+    #define MAX_SERVICE_CODE_CMD_SIZE 6
     ServiceCodeRuntime serviceCodeCmdQueue[MAX_SERVICE_CODE_CMD_SIZE] = {
         ServiceCodeRuntime{Status::REQUEST_CODE::COMPRESSOR_STARTS, 30*60, std::chrono::steady_clock::now() - std::chrono::seconds(60*60)},
         ServiceCodeRuntime{Status::REQUEST_CODE::TH4_DISCHARGE_TEMP, 0, std::chrono::steady_clock::time_point{}},
         ServiceCodeRuntime{Status::REQUEST_CODE::TH3_LIQUID_PIPE1_TEMP, 0, std::chrono::steady_clock::time_point{}},
-        ServiceCodeRuntime{Status::REQUEST_CODE::TH6_2_PHASE_PIPE_TEMP, 0, std::chrono::steady_clock::time_point{}},
-        ServiceCodeRuntime{Status::REQUEST_CODE::TH32_SUCTION_PIPE_TEMP, 0, std::chrono::steady_clock::time_point{}},
-        ServiceCodeRuntime{Status::REQUEST_CODE::TH8_HEAT_SINK_TEMP, 0, std::chrono::steady_clock::time_point{}},
+        //ServiceCodeRuntime{Status::REQUEST_CODE::TH6_2_PHASE_PIPE_TEMP, 0, std::chrono::steady_clock::time_point{}},
+        //ServiceCodeRuntime{Status::REQUEST_CODE::TH32_SUCTION_PIPE_TEMP, 0, std::chrono::steady_clock::time_point{}},
+        //ServiceCodeRuntime{Status::REQUEST_CODE::TH8_HEAT_SINK_TEMP, 0, std::chrono::steady_clock::time_point{}},
         ServiceCodeRuntime{Status::REQUEST_CODE::DISCHARGE_SUPERHEAT, 0, std::chrono::steady_clock::time_point{}},
         ServiceCodeRuntime{Status::REQUEST_CODE::SUB_COOL, 0, std::chrono::steady_clock::time_point{}},
         ServiceCodeRuntime{Status::REQUEST_CODE::FAN_SPEED, 0, std::chrono::steady_clock::time_point{}}
     };
-
 
     bool EcodanHeatpump::dispatch_next_status_cmd()
     {
@@ -262,7 +261,7 @@ namespace ecodan
 
         loopIndex = (loopIndex + 1) % MAX_STATUS_CMD_SIZE;
 
-        if (loopIndex == 0) {
+        if (hasRequestCodeSensors && loopIndex == 0) {
             int counter = 0;
             while (counter <= MAX_SERVICE_CODE_CMD_SIZE && activeRequestCode == Status::REQUEST_CODE::NONE) {
                 counter++;

--- a/components/ecodan/ecodan.h
+++ b/components/ecodan/ecodan.h
@@ -40,6 +40,10 @@ namespace ecodan
             binarySensors[key] = obj;
         }
 
+        void enable_request_codes() {
+            hasRequestCodeSensors = true;
+        }
+
         // exposed as external component commands
         void set_room_temperature(float value, esphome::ecodan::SetZone zone);
         void set_flow_target_temperature(float value, esphome::ecodan::SetZone zone);
@@ -87,6 +91,7 @@ namespace ecodan
         bool connected = false;
         bool heatpumpInitialized = false;
         
+        bool hasRequestCodeSensors = false;
         Status::REQUEST_CODE activeRequestCode = Status::REQUEST_CODE::NONE;
         std::queue<Message> cmdQueue;
 

--- a/components/ecodan/ecodan.h
+++ b/components/ecodan/ecodan.h
@@ -87,6 +87,7 @@ namespace ecodan
         bool connected = false;
         bool heatpumpInitialized = false;
         
+        Status::REQUEST_CODE activeRequestCode = Status::REQUEST_CODE::NONE;
         std::queue<Message> cmdQueue;
 
         bool serial_rx(uart::UARTComponent *uart, Message& msg, bool count_sync_errors = false);
@@ -95,6 +96,7 @@ namespace ecodan
         bool dispatch_next_status_cmd();
         bool dispatch_next_cmd();
         bool schedule_cmd(Message& cmd);
+        bool handle_active_request_codes();
         
         void handle_response(Message& res);
         void handle_get_response(Message& res);

--- a/components/ecodan/response.cpp
+++ b/components/ecodan/response.cpp
@@ -81,6 +81,7 @@ namespace ecodan
                     }
                 }
             }
+            break;
         case GetType::DATETIME_FIRMWARE:
             {
                 status.ControllerDateTime.tm_year = 100 + res[1];
@@ -92,7 +93,7 @@ namespace ecodan
 
                 char firmware[6];
                 snprintf(firmware, 6, "%02X.%02X", res[7], res[8]);
-                publish_state("controller_firmware_text", std::string(firmware));                
+                publish_state("controller_firmware_text", std::string(firmware));
             }
             break;               
         case GetType::DEFROST_STATE:

--- a/components/ecodan/response.cpp
+++ b/components/ecodan/response.cpp
@@ -36,274 +36,316 @@ namespace ecodan
 
     void EcodanHeatpump::handle_get_response(Message& res)
     {
+        switch (res.payload_type<GetType>())
         {
-            switch (res.payload_type<GetType>())
-            {
-            case GetType::DATETIME_FIRMWARE:
-                {
-                    status.ControllerDateTime.tm_year = 100 + res[1];
-                    status.ControllerDateTime.tm_mon = res[2] - 1;
-                    status.ControllerDateTime.tm_mday = res[3];
-                    status.ControllerDateTime.tm_hour = res[4];
-                    status.ControllerDateTime.tm_min = res[5];
-                    status.ControllerDateTime.tm_sec = res[6];                    
-
-                    char firmware[6];
-                    snprintf(firmware, 6, "%02X.%02X", res[7], res[8]);
-                    publish_state("controller_firmware_text", std::string(firmware));                
+        case GetType::SERVICE_REQUEST_CODE:
+            if (res[3] != 0 && (activeRequestCode != Status::REQUEST_CODE::NONE || proxy_available())) {
+                auto res_request_code = static_cast<Status::REQUEST_CODE>(res.get_int16(1));
+                if (activeRequestCode == res_request_code) {
+                    activeRequestCode = Status::REQUEST_CODE::NONE;
                 }
-                break;               
-            case GetType::DEFROST_STATE:
-                status.DefrostActive = res[3] != 0;
-                publish_state("status_defrost", status.DefrostActive);
-                break;
-            case GetType::ERROR_STATE:
-                // 1 = refrigerant error code
-                // 2+3 = fault code, [2]*100+[3]
-                // 4+5 = fault code: letter 2, 0x00 0x03 = A3
-                status.RefrigerantErrorCode = res[1];
-                status.FaultCodeNumeric = res.get_u16(2);
-                status.FaultCodeLetters = res.get_u16(4);
-                status.MultiZoneStatus = res[8];
 
-                publish_state("refrigerant_error_code", static_cast<float>(status.RefrigerantErrorCode));
-                publish_state("fault_code_text", decode_error(res[4], res[5], status.FaultCodeNumeric));
-                publish_state("status_multi_zone", static_cast<float>(status.MultiZoneStatus));
-                break;
-            case GetType::COMPRESSOR_FREQUENCY:
-                status.CompressorFrequency = res[1];
-                publish_state("compressor_frequency", static_cast<float>(status.CompressorFrequency));
-                break;
-            case GetType::DHW_STATE:
-                // 6 = heat source , 0x0 = heatpump, 0x1 = screw in heater, 0x2 = electric heater..
-                status.HeatSource = res[6];
-                //status.DhwForcedActive = res[7] != 0 && res[5] == 0; // byte 5 -> 7 is normal dhw, 0 - forced dhw
-                //publish_state("status_dhw_forced", status.DhwForcedActive ? "On" : "Off");
+                if (res[3] == 2) {
+                    switch(res_request_code) {
+                        case Status::REQUEST_CODE::COMPRESSOR_STARTS:
+                            status.RcCompressorStarts = res.get_int16_v2(4) * 100;
+                            publish_state("compressor_starts", static_cast<float>(status.RcCompressorStarts));
+                        break;
+                        case Status::REQUEST_CODE::TH4_DISCHARGE_TEMP:
+                            status.RcDischargeTemp = static_cast<int8_t>(res[4]);
+                            publish_state("discharge_temp", static_cast<float>(status.RcDischargeTemp));
+                        break;
+                        case Status::REQUEST_CODE::TH3_LIQUID_PIPE1_TEMP:
+                            status.RcLiquidPipeTemp = res.get_int16_v2(4);
+                            publish_state("liquid_pipe_temp", status.RcLiquidPipeTemp); 
+                        break;
+                        case Status::REQUEST_CODE::TH6_2_PHASE_PIPE_TEMP:
+                            status.RcTwoPhasePipeTemp = res.get_int16_v2(4);
+                            publish_state("two_phase_pipe_temp", status.RcTwoPhasePipeTemp); 
+                        break;
+                        case Status::REQUEST_CODE::DISCHARGE_SUPERHEAT:
+                            status.RcDischargeSuperHeatTemp = static_cast<uint8_t>(res[4]);
+                            publish_state("super_heat_temp", static_cast<float>(status.RcDischargeSuperHeatTemp));
+                        break;
+                        case Status::REQUEST_CODE::SUB_COOL:
+                            status.RcSubCoolTemp = static_cast<uint8_t>(res[4]);
+                            publish_state("sub_cool_temp", static_cast<float>(status.RcSubCoolTemp));
+                        break;
+                        case Status::REQUEST_CODE::FAN_SPEED:
+                            status.RcFanSpeedRpm = res.get_int16_v2(4);
+                            publish_state("fan_speed", static_cast<float>(status.RcFanSpeedRpm));
+                        break;
 
-                publish_state("heat_source", static_cast<float>(status.HeatSource));
-                break;
-            case GetType::HEATING_POWER:
-                status.OutputPower = res[6];
-                status.EnergyConsumedIncreasing = res.get_u16(11) / 10.0f;
-                //status.BoosterActive = res[4] == 2;
-                publish_state("output_power", static_cast<float>(status.OutputPower));
-                publish_state("energy_consumed_increasing", status.EnergyConsumedIncreasing);
-                //publish_state("status_booster", status.BoosterActive ? "On" : "Off");
-                break;
-            case GetType::TEMPERATURE_CONFIG:
-                status.Zone1SetTemperature = res.get_float16(1);
-                status.Zone2SetTemperature = res.get_float16(3);
-                status.Zone1FlowTemperatureSetPoint = res.get_float16(5);
-                status.Zone2FlowTemperatureSetPoint = res.get_float16(7);
-                status.LegionellaPreventionSetPoint = res.get_float16(9);
-                status.DhwTemperatureDrop = res.get_float8_v2(11);
-                status.MaximumFlowTemperature = res.get_float8_v2(12);
-                status.MinimumFlowTemperature = res.get_float8_v2(13);
-
-                publish_state("z1_room_temp_target", status.Zone1SetTemperature);
-                publish_state("z2_room_temp_target", status.Zone2SetTemperature);
-                publish_state("z1_flow_temp_target", status.Zone1FlowTemperatureSetPoint);
-                publish_state("z2_flow_temp_target", status.Zone2FlowTemperatureSetPoint);
-
-                publish_state("legionella_prevention_temp", status.LegionellaPreventionSetPoint);
-                publish_state("dhw_flow_temp_drop", status.DhwTemperatureDrop);
-                //ESP_LOGW(TAG, res.debug_dump_packet().c_str());
-                // min/max flow
-
-                break;
-            case GetType::SH_TEMPERATURE_STATE:
-                // 0xF0 seems to be a sentinel value for "not reported in the current system"
-                status.Zone1RoomTemperature = res[1] != 0xF0 ? res.get_float16(1) : 0.0f;
-                status.Zone2RoomTemperature = res[3] != 0xF0 ? res.get_float16(3) : 0.0f;
-                status.OutsideTemperature = res.get_float8(11);
-                status.HpRefrigerantLiquidTemperature = res.get_float16_signed(8);
-
-                publish_state("z1_room_temp", status.Zone1RoomTemperature);
-                publish_state("z2_room_temp", status.Zone2RoomTemperature);
-                publish_state("outside_temp", status.OutsideTemperature);
-                publish_state("hp_refrigerant_temp", status.HpRefrigerantLiquidTemperature);
-                //ESP_LOGE(TAG, "0x0b offset 10: \t%f (v1), \t%f (v2), \t%f (v3)", res.get_float8(10), res.get_float8_v2(10), res.get_float8_v3(10));
-                break;
-            case GetType::TEMPERATURE_STATE_A:
-                status.HpFeedTemperature = res.get_float16(1);
-                status.HpReturnTemperature = res.get_float16(4);
-                status.DhwTemperature = res.get_float16(7);
-                status.DhwSecondaryTemperature = res.get_float16(10); 
-
-                publish_state("hp_feed_temp", status.HpFeedTemperature);
-                publish_state("hp_return_temp", status.HpReturnTemperature);
-                publish_state("dhw_temp", status.DhwTemperature);
-                publish_state("dhw_secondary_temp", status.DhwSecondaryTemperature);
-                status.update_output_power_estimation(specificHeatConstantOverride);
-                publish_state("computed_output_power", status.ComputedOutputPower);
-                break;
-            case GetType::TEMPERATURE_STATE_B:
-                status.Z1FeedTemperature = res.get_float16(1);
-                status.Z1ReturnTemperature = res.get_float16(4);
-
-                status.Z2FeedTemperature = res.get_float16(7);
-                status.Z2ReturnTemperature = res.get_float16(10);
-
-                publish_state("z1_feed_temp", status.Z1FeedTemperature);
-                publish_state("z1_return_temp", status.Z1ReturnTemperature);
-                publish_state("z2_feed_temp", status.Z2FeedTemperature);
-                publish_state("z2_return_temp", status.Z2ReturnTemperature);                                  
-                break;
-            case GetType::TEMPERATURE_STATE_C:
-                status.BoilerFlowTemperature = res.get_float16(1);
-                status.BoilerReturnTemperature = res.get_float16(4);
-                publish_state("boiler_flow_temp", status.BoilerFlowTemperature);
-                publish_state("boiler_return_temp", status.BoilerReturnTemperature);   
-                break;
-            case GetType::TEMPERATURE_STATE_D:
-                status.MixingTankTemperature = res.get_float16(1);
-                status.HpRefrigerantCondensingTemperature = res.get_float16_signed(4);
-                publish_state("mixing_tank_temp", status.MixingTankTemperature);
-                publish_state("hp_refrigerant_condensing_temp", status.HpRefrigerantCondensingTemperature);
-                //ESP_LOGE(TAG, "0x0f offset 6: \t%f (v1), \t%f (v2), \t%f (v3)", res.get_float8(6), res.get_float8_v2(6), res.get_float8_v3(6));
-                break;  
-            case GetType::EXTERNAL_STATE:
-                // 1 = IN1 Thermostat heat/cool request
-                // 2 = IN6 Thermostat 2
-                // 3 = IN5 outdoor thermostat
-                status.In1ThermostatRequest = res[1] != 0;
-                status.In6ThermostatRequest = res[2] != 0;
-                status.In5ThermostatRequest = res[3] != 0;
-                publish_state("status_in1_request", status.In1ThermostatRequest);
-                publish_state("status_in6_request", status.In6ThermostatRequest);
-                publish_state("status_in5_request", status.In5ThermostatRequest);
-                break;
-            case GetType::ACTIVE_TIME:
-                status.Runtime = res.get_float24_v2(3);
-                publish_state("runtime", status.Runtime);
-                //ESP_LOGI(TAG, res.debug_dump_packet().c_str());
-                break;
-            case GetType::PUMP_STATUS:
-                // byte 1 = pump running on/off
-                // byte 4 = pump 2
-                // byte 5 = pump 3
-                // byte 6 = 3 way valve on/off
-                // byte 7 - 3 way valve 2   
-                // byte 10 - Mixing valve step         
-                // byte 11 - Mixing valve status
-                status.WaterPumpActive = res[1] != 0;
-                status.ThreeWayValveActive = res[6] != 0;
-                status.WaterPump2Active = res[4] != 0;
-                status.ThreeWayValve2Active = res[7] != 0;         
-                status.WaterPump3Active = res[5] != 0;       
-                status.MixingValveStep = res[10];   
-                status.MixingValveStatus = res[11];   
-                publish_state("status_water_pump", status.WaterPumpActive);
-                publish_state("status_three_way_valve", status.ThreeWayValveActive);
-                publish_state("status_water_pump_2", status.WaterPump2Active);
-                publish_state("status_three_way_valve_2", status.ThreeWayValve2Active);
-                publish_state("status_water_pump_3", status.WaterPump3Active);
-                publish_state("status_mixing_valve", static_cast<float>(status.MixingValveStatus));
-                publish_state("mixing_valve_step", static_cast<float>(status.MixingValveStep));
-                //ESP_LOGI(TAG, res.debug_dump_packet().c_str());
-                break;              
-            case GetType::FLOW_RATE:
-                // booster = 2, 
-                // emmersion = 5
-                status.BoosterActive = res[2] != 0;
-                status.Booster2Active = res[3] != 0;
-                status.ImmersionActive = res[5] != 0;
-                status.FlowRate = res[12];
-                publish_state("flow_rate", static_cast<float>(status.FlowRate));
-                publish_state("status_booster", status.BoosterActive);
-                publish_state("status_booster_2", status.Booster2Active);
-                publish_state("status_immersion", status.ImmersionActive);
-                status.update_output_power_estimation(specificHeatConstantOverride);
-                publish_state("computed_output_power", status.ComputedOutputPower);
-                break;
-            case GetType::MODE_FLAGS_A:
-                //ESP_LOGE(TAG, res.debug_dump_packet().c_str());
-                status.set_power_mode(res[3]);
-                status.set_operation_mode(res[4]);
-                status.set_dhw_mode(res[5]);
-
-                status.MRCFlag = static_cast<Status::MRC_FLAG>(res[14]);
-                status.HeatingCoolingMode = static_cast<Status::HpMode>(res[6]);
-                status.HeatingCoolingModeZone2 = static_cast<Status::HpMode>(res[7]);
-                status.DhwFlowTemperatureSetPoint = res.get_float16(8);
-                //status.RadiatorFlowTemperatureSetPoint = res.get_float16(12);
-
-                publish_state("status_power", status.Power == Status::PowerMode::ON);
-                publish_state("status_dhw_eco", status.HotWaterMode == Status::DhwMode::ECO);
-                publish_state("status_operation", static_cast<float>(status.Operation));
-                publish_state("status_heating_cooling", static_cast<float>(status.HeatingCoolingMode));
-                publish_state("status_heating_cooling_z2", static_cast<float>(status.HeatingCoolingModeZone2));
-
-                publish_state("dhw_flow_temp_target", status.DhwFlowTemperatureSetPoint);
-                //publish_state("sh_flow_temp_target", status.RadiatorFlowTemperatureSetPoint);
-                break;
-            case GetType::MODE_FLAGS_B:
-                status.DhwForcedActive = res[3] != 0;
-                status.HolidayMode = res[4] != 0;
-                status.ProhibitDhw = res[5] != 0;
-                status.ProhibitHeatingZ1 = res[6] != 0;
-                status.ProhibitCoolingZ1 = res[7] != 0;
-                status.ProhibitHeatingZ2 = res[8] != 0;
-                status.ProhibitCoolingZ2 = res[9] != 0;
-                
-                publish_state("status_dhw_forced", status.DhwForcedActive);
-                publish_state("status_holiday", status.HolidayMode);
-                publish_state("status_prohibit_dhw", status.ProhibitDhw);
-                publish_state("status_prohibit_heating_z1", status.ProhibitHeatingZ1);
-                publish_state("status_prohibit_cool_z1", status.ProhibitCoolingZ1);
-                publish_state("status_prohibit_heating_z2", status.ProhibitHeatingZ2);
-                publish_state("status_prohibit_cool_z2", status.ProhibitCoolingZ2);
-
-                status.ServerControl = res[10] != 0;
-                publish_state("status_server_control", status.ServerControl);
-
-                // set status for svc switches
-                publish_state("status_server_control_prohibit_dhw", status.ServerControl ? status.ProhibitDhw : false);
-                publish_state("status_server_control_prohibit_heating_z1", status.ServerControl ? status.ProhibitHeatingZ1 : false);
-                publish_state("status_server_control_prohibit_cool_z1", status.ServerControl ? status.ProhibitCoolingZ1 : false);
-                publish_state("status_server_control_prohibit_heating_z2", status.ServerControl ? status.ProhibitHeatingZ2 : false);
-                publish_state("status_server_control_prohibit_cool_z2", status.ServerControl ? status.ProhibitCoolingZ2 : false);
-                break;
-            case GetType::ENERGY_USAGE:
-                status.EnergyConsumedHeating = res.get_float24(4);
-                status.EnergyConsumedCooling = res.get_float24(7);
-                status.EnergyConsumedDhw = res.get_float24(10);
-
-                publish_state("heating_consumed", status.EnergyConsumedHeating);
-                publish_state("cool_consumed", status.EnergyConsumedCooling);
-                publish_state("dhw_consumed", status.EnergyConsumedDhw);
-                break;
-            case GetType::ENERGY_DELIVERY:
-                status.EnergyDeliveredHeating = res.get_float24(4);
-                status.EnergyDeliveredCooling = res.get_float24(7);
-                status.EnergyDeliveredDhw = res.get_float24(10);
-
-                publish_state("heating_delivered", status.EnergyDeliveredHeating);
-                publish_state("cool_delivered", status.EnergyDeliveredCooling);
-                publish_state("dhw_delivered", status.EnergyDeliveredDhw);
-                
-                publish_state("heating_cop", status.EnergyConsumedHeating > 0.0f ? status.EnergyDeliveredHeating / status.EnergyConsumedHeating : 0.0f);
-                publish_state("cool_cop", status.EnergyConsumedCooling > 0.0f ? status.EnergyDeliveredCooling / status.EnergyConsumedCooling : 0.0f);
-                publish_state("dhw_cop", status.EnergyConsumedDhw > 0.0f ? status.EnergyDeliveredDhw / status.EnergyConsumedDhw : 0.0f);
-
-                break;
-            case GetType::HARDWARE_CONFIGURATION:
-                // byte 6 = ftc, ft2b , ftc4, ftc5, ftc6
-                status.Controller = res[6];
-                publish_state("controller_version", static_cast<float>(status.Controller));
-                break;
-            case GetType::DIP_SWITCHES:
-                status.DipSwitch1 = res[1];
-                status.DipSwitch2 = res[3];
-                status.DipSwitch3 = res[5];
-                status.DipSwitch4 = res[7];
-                status.DipSwitch5 = res[9];
-                status.DipSwitch6 = res[11];
-                break;
-            default:
-                ESP_LOGI(TAG, "Unknown response type received on serial port: %u", static_cast<uint8_t>(res.payload_type<GetType>()));
-                break;
+                        default:
+                        break;
+                    }
+                }
             }
+        case GetType::DATETIME_FIRMWARE:
+            {
+                status.ControllerDateTime.tm_year = 100 + res[1];
+                status.ControllerDateTime.tm_mon = res[2] - 1;
+                status.ControllerDateTime.tm_mday = res[3];
+                status.ControllerDateTime.tm_hour = res[4];
+                status.ControllerDateTime.tm_min = res[5];
+                status.ControllerDateTime.tm_sec = res[6];                    
+
+                char firmware[6];
+                snprintf(firmware, 6, "%02X.%02X", res[7], res[8]);
+                publish_state("controller_firmware_text", std::string(firmware));                
+            }
+            break;               
+        case GetType::DEFROST_STATE:
+            status.DefrostActive = res[3] != 0;
+            publish_state("status_defrost", status.DefrostActive);
+            break;
+        case GetType::ERROR_STATE:
+            // 1 = refrigerant error code
+            // 2+3 = fault code, [2]*100+[3]
+            // 4+5 = fault code: letter 2, 0x00 0x03 = A3
+            status.RefrigerantErrorCode = res[1];
+            status.FaultCodeNumeric = res.get_u16(2);
+            status.FaultCodeLetters = res.get_u16(4);
+            status.MultiZoneStatus = res[8];
+
+            publish_state("refrigerant_error_code", static_cast<float>(status.RefrigerantErrorCode));
+            publish_state("fault_code_text", decode_error(res[4], res[5], status.FaultCodeNumeric));
+            publish_state("status_multi_zone", static_cast<float>(status.MultiZoneStatus));
+            break;
+        case GetType::COMPRESSOR_FREQUENCY:
+            status.CompressorFrequency = res[1];
+            publish_state("compressor_frequency", static_cast<float>(status.CompressorFrequency));
+            break;
+        case GetType::DHW_STATE:
+            // 6 = heat source , 0x0 = heatpump, 0x1 = screw in heater, 0x2 = electric heater..
+            status.HeatSource = res[6];
+            //status.DhwForcedActive = res[7] != 0 && res[5] == 0; // byte 5 -> 7 is normal dhw, 0 - forced dhw
+            //publish_state("status_dhw_forced", status.DhwForcedActive ? "On" : "Off");
+
+            publish_state("heat_source", static_cast<float>(status.HeatSource));
+            break;
+        case GetType::HEATING_POWER:
+            status.OutputPower = res[6];
+            status.EnergyConsumedIncreasing = res.get_u16(11) / 10.0f;
+            //status.BoosterActive = res[4] == 2;
+            publish_state("output_power", static_cast<float>(status.OutputPower));
+            publish_state("energy_consumed_increasing", status.EnergyConsumedIncreasing);
+            //publish_state("status_booster", status.BoosterActive ? "On" : "Off");
+            break;
+        case GetType::TEMPERATURE_CONFIG:
+            status.Zone1SetTemperature = res.get_float16(1);
+            status.Zone2SetTemperature = res.get_float16(3);
+            status.Zone1FlowTemperatureSetPoint = res.get_float16(5);
+            status.Zone2FlowTemperatureSetPoint = res.get_float16(7);
+            status.LegionellaPreventionSetPoint = res.get_float16(9);
+            status.DhwTemperatureDrop = res.get_float8_v2(11);
+            status.MaximumFlowTemperature = res.get_float8_v2(12);
+            status.MinimumFlowTemperature = res.get_float8_v2(13);
+
+            publish_state("z1_room_temp_target", status.Zone1SetTemperature);
+            publish_state("z2_room_temp_target", status.Zone2SetTemperature);
+            publish_state("z1_flow_temp_target", status.Zone1FlowTemperatureSetPoint);
+            publish_state("z2_flow_temp_target", status.Zone2FlowTemperatureSetPoint);
+
+            publish_state("legionella_prevention_temp", status.LegionellaPreventionSetPoint);
+            publish_state("dhw_flow_temp_drop", status.DhwTemperatureDrop);
+            //ESP_LOGW(TAG, res.debug_dump_packet().c_str());
+            // min/max flow
+
+            break;
+        case GetType::SH_TEMPERATURE_STATE:
+            // 0xF0 seems to be a sentinel value for "not reported in the current system"
+            status.Zone1RoomTemperature = res[1] != 0xF0 ? res.get_float16(1) : 0.0f;
+            status.Zone2RoomTemperature = res[3] != 0xF0 ? res.get_float16(3) : 0.0f;
+            status.OutsideTemperature = res.get_float8(11);
+            status.HpRefrigerantLiquidTemperature = res.get_float16_signed(8);
+
+            publish_state("z1_room_temp", status.Zone1RoomTemperature);
+            publish_state("z2_room_temp", status.Zone2RoomTemperature);
+            publish_state("outside_temp", status.OutsideTemperature);
+            publish_state("hp_refrigerant_temp", status.HpRefrigerantLiquidTemperature);
+            //ESP_LOGE(TAG, "0x0b offset 10: \t%f (v1), \t%f (v2), \t%f (v3)", res.get_float8(10), res.get_float8_v2(10), res.get_float8_v3(10));
+            break;
+        case GetType::TEMPERATURE_STATE_A:
+            status.HpFeedTemperature = res.get_float16(1);
+            status.HpReturnTemperature = res.get_float16(4);
+            status.DhwTemperature = res.get_float16(7);
+            status.DhwSecondaryTemperature = res.get_float16(10); 
+
+            publish_state("hp_feed_temp", status.HpFeedTemperature);
+            publish_state("hp_return_temp", status.HpReturnTemperature);
+            publish_state("dhw_temp", status.DhwTemperature);
+            publish_state("dhw_secondary_temp", status.DhwSecondaryTemperature);
+            status.update_output_power_estimation(specificHeatConstantOverride);
+            publish_state("computed_output_power", status.ComputedOutputPower);
+            break;
+        case GetType::TEMPERATURE_STATE_B:
+            status.Z1FeedTemperature = res.get_float16(1);
+            status.Z1ReturnTemperature = res.get_float16(4);
+
+            status.Z2FeedTemperature = res.get_float16(7);
+            status.Z2ReturnTemperature = res.get_float16(10);
+
+            publish_state("z1_feed_temp", status.Z1FeedTemperature);
+            publish_state("z1_return_temp", status.Z1ReturnTemperature);
+            publish_state("z2_feed_temp", status.Z2FeedTemperature);
+            publish_state("z2_return_temp", status.Z2ReturnTemperature);                                  
+            break;
+        case GetType::TEMPERATURE_STATE_C:
+            status.BoilerFlowTemperature = res.get_float16(1);
+            status.BoilerReturnTemperature = res.get_float16(4);
+            publish_state("boiler_flow_temp", status.BoilerFlowTemperature);
+            publish_state("boiler_return_temp", status.BoilerReturnTemperature);   
+            break;
+        case GetType::TEMPERATURE_STATE_D:
+            status.MixingTankTemperature = res.get_float16(1);
+            status.HpRefrigerantCondensingTemperature = res.get_float16_signed(4);
+            publish_state("mixing_tank_temp", status.MixingTankTemperature);
+            publish_state("hp_refrigerant_condensing_temp", status.HpRefrigerantCondensingTemperature);
+            //ESP_LOGE(TAG, "0x0f offset 6: \t%f (v1), \t%f (v2), \t%f (v3)", res.get_float8(6), res.get_float8_v2(6), res.get_float8_v3(6));
+            break;  
+        case GetType::EXTERNAL_STATE:
+            // 1 = IN1 Thermostat heat/cool request
+            // 2 = IN6 Thermostat 2
+            // 3 = IN5 outdoor thermostat
+            status.In1ThermostatRequest = res[1] != 0;
+            status.In6ThermostatRequest = res[2] != 0;
+            status.In5ThermostatRequest = res[3] != 0;
+            publish_state("status_in1_request", status.In1ThermostatRequest);
+            publish_state("status_in6_request", status.In6ThermostatRequest);
+            publish_state("status_in5_request", status.In5ThermostatRequest);
+            break;
+        case GetType::ACTIVE_TIME:
+            status.Runtime = res.get_float24_v2(3);
+            publish_state("runtime", status.Runtime);
+            //ESP_LOGI(TAG, res.debug_dump_packet().c_str());
+            break;
+        case GetType::PUMP_STATUS:
+            // byte 1 = pump running on/off
+            // byte 4 = pump 2
+            // byte 5 = pump 3
+            // byte 6 = 3 way valve on/off
+            // byte 7 - 3 way valve 2   
+            // byte 10 - Mixing valve step         
+            // byte 11 - Mixing valve status
+            status.WaterPumpActive = res[1] != 0;
+            status.ThreeWayValveActive = res[6] != 0;
+            status.WaterPump2Active = res[4] != 0;
+            status.ThreeWayValve2Active = res[7] != 0;         
+            status.WaterPump3Active = res[5] != 0;       
+            status.MixingValveStep = res[10];   
+            status.MixingValveStatus = res[11];   
+            publish_state("status_water_pump", status.WaterPumpActive);
+            publish_state("status_three_way_valve", status.ThreeWayValveActive);
+            publish_state("status_water_pump_2", status.WaterPump2Active);
+            publish_state("status_three_way_valve_2", status.ThreeWayValve2Active);
+            publish_state("status_water_pump_3", status.WaterPump3Active);
+            publish_state("status_mixing_valve", static_cast<float>(status.MixingValveStatus));
+            publish_state("mixing_valve_step", static_cast<float>(status.MixingValveStep));
+            //ESP_LOGI(TAG, res.debug_dump_packet().c_str());
+            break;              
+        case GetType::FLOW_RATE:
+            // booster = 2, 
+            // emmersion = 5
+            status.BoosterActive = res[2] != 0;
+            status.Booster2Active = res[3] != 0;
+            status.ImmersionActive = res[5] != 0;
+            status.FlowRate = res[12];
+            publish_state("flow_rate", static_cast<float>(status.FlowRate));
+            publish_state("status_booster", status.BoosterActive);
+            publish_state("status_booster_2", status.Booster2Active);
+            publish_state("status_immersion", status.ImmersionActive);
+            status.update_output_power_estimation(specificHeatConstantOverride);
+            publish_state("computed_output_power", status.ComputedOutputPower);
+            break;
+        case GetType::MODE_FLAGS_A:
+            //ESP_LOGE(TAG, res.debug_dump_packet().c_str());
+            status.set_power_mode(res[3]);
+            status.set_operation_mode(res[4]);
+            status.set_dhw_mode(res[5]);
+
+            status.MRCFlag = static_cast<Status::MRC_FLAG>(res[14]);
+            status.HeatingCoolingMode = static_cast<Status::HpMode>(res[6]);
+            status.HeatingCoolingModeZone2 = static_cast<Status::HpMode>(res[7]);
+            status.DhwFlowTemperatureSetPoint = res.get_float16(8);
+            //status.RadiatorFlowTemperatureSetPoint = res.get_float16(12);
+
+            publish_state("status_power", status.Power == Status::PowerMode::ON);
+            publish_state("status_dhw_eco", status.HotWaterMode == Status::DhwMode::ECO);
+            publish_state("status_operation", static_cast<float>(status.Operation));
+            publish_state("status_heating_cooling", static_cast<float>(status.HeatingCoolingMode));
+            publish_state("status_heating_cooling_z2", static_cast<float>(status.HeatingCoolingModeZone2));
+
+            publish_state("dhw_flow_temp_target", status.DhwFlowTemperatureSetPoint);
+            //publish_state("sh_flow_temp_target", status.RadiatorFlowTemperatureSetPoint);
+            break;
+        case GetType::MODE_FLAGS_B:
+            status.DhwForcedActive = res[3] != 0;
+            status.HolidayMode = res[4] != 0;
+            status.ProhibitDhw = res[5] != 0;
+            status.ProhibitHeatingZ1 = res[6] != 0;
+            status.ProhibitCoolingZ1 = res[7] != 0;
+            status.ProhibitHeatingZ2 = res[8] != 0;
+            status.ProhibitCoolingZ2 = res[9] != 0;
+            
+            publish_state("status_dhw_forced", status.DhwForcedActive);
+            publish_state("status_holiday", status.HolidayMode);
+            publish_state("status_prohibit_dhw", status.ProhibitDhw);
+            publish_state("status_prohibit_heating_z1", status.ProhibitHeatingZ1);
+            publish_state("status_prohibit_cool_z1", status.ProhibitCoolingZ1);
+            publish_state("status_prohibit_heating_z2", status.ProhibitHeatingZ2);
+            publish_state("status_prohibit_cool_z2", status.ProhibitCoolingZ2);
+
+            status.ServerControl = res[10] != 0;
+            publish_state("status_server_control", status.ServerControl);
+
+            // set status for svc switches
+            publish_state("status_server_control_prohibit_dhw", status.ServerControl ? status.ProhibitDhw : false);
+            publish_state("status_server_control_prohibit_heating_z1", status.ServerControl ? status.ProhibitHeatingZ1 : false);
+            publish_state("status_server_control_prohibit_cool_z1", status.ServerControl ? status.ProhibitCoolingZ1 : false);
+            publish_state("status_server_control_prohibit_heating_z2", status.ServerControl ? status.ProhibitHeatingZ2 : false);
+            publish_state("status_server_control_prohibit_cool_z2", status.ServerControl ? status.ProhibitCoolingZ2 : false);
+            break;
+        case GetType::ENERGY_USAGE:
+            status.EnergyConsumedHeating = res.get_float24(4);
+            status.EnergyConsumedCooling = res.get_float24(7);
+            status.EnergyConsumedDhw = res.get_float24(10);
+
+            publish_state("heating_consumed", status.EnergyConsumedHeating);
+            publish_state("cool_consumed", status.EnergyConsumedCooling);
+            publish_state("dhw_consumed", status.EnergyConsumedDhw);
+            break;
+        case GetType::ENERGY_DELIVERY:
+            status.EnergyDeliveredHeating = res.get_float24(4);
+            status.EnergyDeliveredCooling = res.get_float24(7);
+            status.EnergyDeliveredDhw = res.get_float24(10);
+
+            publish_state("heating_delivered", status.EnergyDeliveredHeating);
+            publish_state("cool_delivered", status.EnergyDeliveredCooling);
+            publish_state("dhw_delivered", status.EnergyDeliveredDhw);
+            
+            publish_state("heating_cop", status.EnergyConsumedHeating > 0.0f ? status.EnergyDeliveredHeating / status.EnergyConsumedHeating : 0.0f);
+            publish_state("cool_cop", status.EnergyConsumedCooling > 0.0f ? status.EnergyDeliveredCooling / status.EnergyConsumedCooling : 0.0f);
+            publish_state("dhw_cop", status.EnergyConsumedDhw > 0.0f ? status.EnergyDeliveredDhw / status.EnergyConsumedDhw : 0.0f);
+
+            break;
+        case GetType::HARDWARE_CONFIGURATION:
+            // byte 6 = ftc, ft2b , ftc4, ftc5, ftc6
+            status.Controller = res[6];
+            publish_state("controller_version", static_cast<float>(status.Controller));
+            break;
+        case GetType::DIP_SWITCHES:
+            status.DipSwitch1 = res[1];
+            status.DipSwitch2 = res[3];
+            status.DipSwitch3 = res[5];
+            status.DipSwitch4 = res[7];
+            status.DipSwitch5 = res[9];
+            status.DipSwitch6 = res[11];
+            break;
+        default:
+            ESP_LOGE(TAG, "Unknown response type received on serial port: %u", static_cast<uint8_t>(res.payload_type<GetType>()));
+            ESP_LOGE(TAG, res.debug_dump_packet().c_str());
+            break;
         }
     }
 

--- a/components/ecodan/response.cpp
+++ b/components/ecodan/response.cpp
@@ -56,20 +56,28 @@ namespace ecodan
                             publish_state("discharge_temp", static_cast<float>(status.RcDischargeTemp));
                         break;
                         case Status::REQUEST_CODE::TH3_LIQUID_PIPE1_TEMP:
-                            status.RcLiquidPipeTemp = res.get_int16_v2(4);
-                            publish_state("liquid_pipe_temp", status.RcLiquidPipeTemp); 
+                            status.RcOuLiquidPipeTemp = res.get_int16_v2(4);
+                            publish_state("ou_liquid_pipe_temp", status.RcOuLiquidPipeTemp); 
                         break;
                         case Status::REQUEST_CODE::TH6_2_PHASE_PIPE_TEMP:
-                            status.RcTwoPhasePipeTemp = res.get_int16_v2(4);
-                            publish_state("two_phase_pipe_temp", status.RcTwoPhasePipeTemp); 
+                            status.RcOuTwoPhasePipeTemp = res.get_int16_v2(4);
+                            publish_state("ou_two_phase_pipe_temp", status.RcOuTwoPhasePipeTemp); 
+                        break;
+                        case Status::REQUEST_CODE::TH32_SUCTION_PIPE_TEMP:
+                            status.RcOuSuctionPipeTemp = res.get_int16_v2(4);
+                            publish_state("ou_suction_pipe_temp", status.RcOuSuctionPipeTemp); 
+                        break;
+                        case Status::REQUEST_CODE::TH8_HEAT_SINK_TEMP:
+                            status.RcOuHeatSinkTemp = res.get_int16_v2(4);
+                            publish_state("ou_heatsink_temp", status.RcOuHeatSinkTemp); 
                         break;
                         case Status::REQUEST_CODE::DISCHARGE_SUPERHEAT:
-                            status.RcDischargeSuperHeatTemp = static_cast<uint8_t>(res[4]);
-                            publish_state("super_heat_temp", static_cast<float>(status.RcDischargeSuperHeatTemp));
+                            status.RcDischargeSuperHeatTemp = res.get_int16_v2(4);
+                            publish_state("super_heat_temp", status.RcDischargeSuperHeatTemp);
                         break;
                         case Status::REQUEST_CODE::SUB_COOL:
-                            status.RcSubCoolTemp = static_cast<uint8_t>(res[4]);
-                            publish_state("sub_cool_temp", static_cast<float>(status.RcSubCoolTemp));
+                            status.RcSubCoolTemp = res.get_int16_v2(4);
+                            publish_state("sub_cool_temp", status.RcSubCoolTemp);
                         break;
                         case Status::REQUEST_CODE::FAN_SPEED:
                             status.RcFanSpeedRpm = res.get_int16_v2(4);

--- a/components/ecodan/sensor.py
+++ b/components/ecodan/sensor.py
@@ -353,20 +353,20 @@ CONFIG_SCHEMA = cv.Schema(
         #     device_class=DEVICE_CLASS_TEMPERATURE,
         #     state_class=STATE_CLASS_MEASUREMENT,
         # ),
-        cv.Optional("super_heat_temp"): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon="mdi:coolant-temperature",
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional("sub_cool_temp"): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon="mdi:coolant-temperature",
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
+        # cv.Optional("super_heat_temp"): sensor.sensor_schema(
+        #     unit_of_measurement=UNIT_CELSIUS,
+        #     icon="mdi:coolant-temperature",
+        #     accuracy_decimals=1,
+        #     device_class=DEVICE_CLASS_TEMPERATURE,
+        #     state_class=STATE_CLASS_MEASUREMENT,
+        # ),
+        # cv.Optional("sub_cool_temp"): sensor.sensor_schema(
+        #     unit_of_measurement=UNIT_CELSIUS,
+        #     icon="mdi:coolant-temperature",
+        #     accuracy_decimals=1,
+        #     device_class=DEVICE_CLASS_TEMPERATURE,
+        #     state_class=STATE_CLASS_MEASUREMENT,
+        # ),
         cv.Optional("fan_speed"): sensor.sensor_schema(
             unit_of_measurement=UNIT_REVOLUTIONS_PER_MINUTE,
             icon="mdi:fan",
@@ -387,5 +387,5 @@ async def to_code(config):
         if id and id.type == sensor.Sensor:
             sens = await sensor.new_sensor(conf)
             cg.add(hp.register_sensor(sens, key))
-            if key in ["compressor_starts", "discharge_temp", "ou_liquid_pipe_temp", "super_heat_temp", "sub_cool_temp", "fan_speed"]:
+            if key in ["compressor_starts", "discharge_temp", "ou_liquid_pipe_temp", "fan_speed"]:
                 cg.add(hp.enable_request_codes())

--- a/components/ecodan/sensor.py
+++ b/components/ecodan/sensor.py
@@ -332,27 +332,27 @@ CONFIG_SCHEMA = cv.Schema(
             device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
-        cv.Optional("ou_two_phase_pipe_temp"): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon="mdi:coolant-temperature",
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional("ou_suction_pipe_temp"): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon="mdi:coolant-temperature",
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional("ou_heatsink_temp"): sensor.sensor_schema(
-            unit_of_measurement=UNIT_CELSIUS,
-            icon="mdi:coolant-temperature",
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_TEMPERATURE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
+        # cv.Optional("ou_two_phase_pipe_temp"): sensor.sensor_schema(
+        #     unit_of_measurement=UNIT_CELSIUS,
+        #     icon="mdi:coolant-temperature",
+        #     accuracy_decimals=1,
+        #     device_class=DEVICE_CLASS_TEMPERATURE,
+        #     state_class=STATE_CLASS_MEASUREMENT,
+        # ),
+        # cv.Optional("ou_suction_pipe_temp"): sensor.sensor_schema(
+        #     unit_of_measurement=UNIT_CELSIUS,
+        #     icon="mdi:coolant-temperature",
+        #     accuracy_decimals=1,
+        #     device_class=DEVICE_CLASS_TEMPERATURE,
+        #     state_class=STATE_CLASS_MEASUREMENT,
+        # ),
+        # cv.Optional("ou_heatsink_temp"): sensor.sensor_schema(
+        #     unit_of_measurement=UNIT_CELSIUS,
+        #     icon="mdi:coolant-temperature",
+        #     accuracy_decimals=1,
+        #     device_class=DEVICE_CLASS_TEMPERATURE,
+        #     state_class=STATE_CLASS_MEASUREMENT,
+        # ),
         cv.Optional("super_heat_temp"): sensor.sensor_schema(
             unit_of_measurement=UNIT_CELSIUS,
             icon="mdi:coolant-temperature",
@@ -387,4 +387,5 @@ async def to_code(config):
         if id and id.type == sensor.Sensor:
             sens = await sensor.new_sensor(conf)
             cg.add(hp.register_sensor(sens, key))
-        
+            if key in ["compressor_starts", "discharge_temp", "ou_liquid_pipe_temp", "super_heat_temp", "sub_cool_temp", "fan_speed"]:
+                cg.add(hp.enable_request_codes())

--- a/components/ecodan/sensor.py
+++ b/components/ecodan/sensor.py
@@ -315,7 +315,7 @@ CONFIG_SCHEMA = cv.Schema(
             state_class=ENTITY_CATEGORY_NONE
         ),
         cv.Optional("compressor_starts"): sensor.sensor_schema(
-            icon="mdi:clock",
+            icon="mdi:counter",
             entity_category=ENTITY_CATEGORY_NONE,
         ),
         cv.Optional("discharge_temp"): sensor.sensor_schema(
@@ -325,37 +325,51 @@ CONFIG_SCHEMA = cv.Schema(
             device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
-        cv.Optional("liquid_pipe_temp"): sensor.sensor_schema(
+        cv.Optional("ou_liquid_pipe_temp"): sensor.sensor_schema(
             unit_of_measurement=UNIT_CELSIUS,
             icon="mdi:coolant-temperature",
             accuracy_decimals=1,
             device_class=DEVICE_CLASS_TEMPERATURE,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
-        # cv.Optional("two_phase_pipe_temp"): sensor.sensor_schema(
-        #     unit_of_measurement=UNIT_CELSIUS,
-        #     icon="mdi:coolant-temperature",
-        #     accuracy_decimals=1,
-        #     device_class=DEVICE_CLASS_TEMPERATURE,
-        #     state_class=STATE_CLASS_MEASUREMENT,
-        # ),
-        # cv.Optional("super_heat_temp"): sensor.sensor_schema(
-        #     unit_of_measurement=UNIT_CELSIUS,
-        #     icon="mdi:coolant-temperature",
-        #     accuracy_decimals=1,
-        #     device_class=DEVICE_CLASS_TEMPERATURE,
-        #     state_class=STATE_CLASS_MEASUREMENT,
-        # ),
-        # cv.Optional("sub_cool_temp"): sensor.sensor_schema(
-        #     unit_of_measurement=UNIT_CELSIUS,
-        #     icon="mdi:coolant-temperature",
-        #     accuracy_decimals=1,
-        #     device_class=DEVICE_CLASS_TEMPERATURE,
-        #     state_class=STATE_CLASS_MEASUREMENT,
-        # ),
+        cv.Optional("ou_two_phase_pipe_temp"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:coolant-temperature",
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("ou_suction_pipe_temp"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:coolant-temperature",
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("ou_heatsink_temp"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:coolant-temperature",
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("super_heat_temp"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:coolant-temperature",
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("sub_cool_temp"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:coolant-temperature",
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
         cv.Optional("fan_speed"): sensor.sensor_schema(
             unit_of_measurement=UNIT_REVOLUTIONS_PER_MINUTE,
-            icon="mdi:sine-wave",
+            icon="mdi:fan",
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_FREQUENCY,
             state_class=STATE_CLASS_MEASUREMENT,

--- a/components/ecodan/sensor.py
+++ b/components/ecodan/sensor.py
@@ -16,6 +16,7 @@ from esphome.const import (
     STATE_CLASS_TOTAL_INCREASING,
     UNIT_CELSIUS,
     UNIT_HERTZ,
+    UNIT_REVOLUTIONS_PER_MINUTE,
     UNIT_HOUR,
     UNIT_KILOWATT,
     UNIT_KILOWATT_HOURS,
@@ -312,7 +313,53 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional("status_multi_zone"): sensor.sensor_schema(
             icon="mdi:thermostat",
             state_class=ENTITY_CATEGORY_NONE
-        ),  
+        ),
+        cv.Optional("compressor_starts"): sensor.sensor_schema(
+            icon="mdi:clock",
+            entity_category=ENTITY_CATEGORY_NONE,
+        ),
+        cv.Optional("discharge_temp"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:coolant-temperature",
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("liquid_pipe_temp"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            icon="mdi:coolant-temperature",
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        # cv.Optional("two_phase_pipe_temp"): sensor.sensor_schema(
+        #     unit_of_measurement=UNIT_CELSIUS,
+        #     icon="mdi:coolant-temperature",
+        #     accuracy_decimals=1,
+        #     device_class=DEVICE_CLASS_TEMPERATURE,
+        #     state_class=STATE_CLASS_MEASUREMENT,
+        # ),
+        # cv.Optional("super_heat_temp"): sensor.sensor_schema(
+        #     unit_of_measurement=UNIT_CELSIUS,
+        #     icon="mdi:coolant-temperature",
+        #     accuracy_decimals=1,
+        #     device_class=DEVICE_CLASS_TEMPERATURE,
+        #     state_class=STATE_CLASS_MEASUREMENT,
+        # ),
+        # cv.Optional("sub_cool_temp"): sensor.sensor_schema(
+        #     unit_of_measurement=UNIT_CELSIUS,
+        #     icon="mdi:coolant-temperature",
+        #     accuracy_decimals=1,
+        #     device_class=DEVICE_CLASS_TEMPERATURE,
+        #     state_class=STATE_CLASS_MEASUREMENT,
+        # ),
+        cv.Optional("fan_speed"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_REVOLUTIONS_PER_MINUTE,
+            icon="mdi:sine-wave",
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_FREQUENCY,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/components/ecodan/status.h
+++ b/components/ecodan/status.h
@@ -124,6 +124,9 @@ namespace ecodan
             TH4_DISCHARGE_TEMP = 4,
             TH3_LIQUID_PIPE1_TEMP = 5,
             TH6_2_PHASE_PIPE_TEMP = 7,
+            TH32_SUCTION_PIPE_TEMP = 8,
+            TH8_HEAT_SINK_TEMP = 10,
+            //TH33_SURFACE_TEMP = 11,
             DISCHARGE_SUPERHEAT = 12,
             SUB_COOL = 13,
             FAN_SPEED = 19,
@@ -161,10 +164,12 @@ namespace ecodan
         // Service codes
         uint16_t RcCompressorStarts;
         float RcDischargeTemp;
-        float RcLiquidPipeTemp;
-        float RcTwoPhasePipeTemp;
-        uint8_t RcDischargeSuperHeatTemp;
-        uint8_t RcSubCoolTemp;
+        float RcOuLiquidPipeTemp;
+        float RcOuTwoPhasePipeTemp;
+        float RcOuSuctionPipeTemp;
+        float RcOuHeatSinkTemp;
+        float RcDischargeSuperHeatTemp;
+        float RcSubCoolTemp;
         uint16_t RcFanSpeedRpm;
 
 /* polynomial fit for

--- a/components/ecodan/status.h
+++ b/components/ecodan/status.h
@@ -118,6 +118,18 @@ namespace ecodan
             SYSTEM_ON_OFF = 0x40
         };
 
+        enum class REQUEST_CODE : int16_t 
+        {
+            COMPRESSOR_STARTS = 3,
+            TH4_DISCHARGE_TEMP = 4,
+            TH3_LIQUID_PIPE1_TEMP = 5,
+            TH6_2_PHASE_PIPE_TEMP = 7,
+            DISCHARGE_SUPERHEAT = 12,
+            SUB_COOL = 13,
+            FAN_SPEED = 19,
+            NONE = 0x7fff
+        };
+
         // Modes
         PowerMode Power;
         OperationMode Operation = OperationMode::UNAVAILABLE;
@@ -145,6 +157,15 @@ namespace ecodan
         float EnergyConsumedDhw;
         float EnergyDeliveredDhw;
         float EnergyConsumedIncreasing{0};
+
+        // Service codes
+        uint16_t RcCompressorStarts;
+        float RcDischargeTemp;
+        float RcLiquidPipeTemp;
+        float RcTwoPhasePipeTemp;
+        uint8_t RcDischargeSuperHeatTemp;
+        uint8_t RcSubCoolTemp;
+        uint16_t RcFanSpeedRpm;
 
 /* polynomial fit for
 Temp C	specific heat (J/Kg. K)

--- a/confs/base.yaml
+++ b/confs/base.yaml
@@ -248,18 +248,24 @@ sensor:
     discharge_temp:
       id: discharge_temp
       name: ${discharge_temp}
-    liquid_pipe_temp:
-      id: liquid_pipe_temp
-      name: ${liquid_pipe_temp}
-    # two_phase_pipe_temp:
-    #   id: two_phase_pipe_temp
-    #   name: two_phase_pipe_temp
-    # super_heat_temp:
-    #   id: super_heat_temp
-    #   name: super_heat_temp
-    # sub_cool_temp:
-    #   id: sub_cool_temp
-    #   name: sub_cool_temp
+    ou_liquid_pipe_temp:
+      id: ou_liquid_pipe_temp
+      name: ${ou_liquid_pipe_temp}
+    ou_two_phase_pipe_temp:
+      id: ou_two_phase_pipe_temp
+      name: ${ou_two_phase_pipe_temp}
+    ou_suction_pipe_temp:
+      id: ou_suction_pipe_temp
+      name: ${ou_suction_pipe_temp}
+    ou_heatsink_temp:
+      id: ou_heatsink_temp
+      name: ${ou_heatsink_temp}
+    super_heat_temp:
+      id: super_heat_temp
+      name: ${super_heat_temp}
+    sub_cool_temp:
+      id: sub_cool_temp
+      name: ${sub_cool_temp}
     fan_speed:
       id: fan_speed
       name: ${fan_speed}

--- a/confs/base.yaml
+++ b/confs/base.yaml
@@ -242,33 +242,6 @@ text_sensor:
 
 sensor:
   - platform: ecodan
-    compressor_starts:
-      id: compressor_starts
-      name: ${compressor_starts}
-    discharge_temp:
-      id: discharge_temp
-      name: ${discharge_temp}
-    ou_liquid_pipe_temp:
-      id: ou_liquid_pipe_temp
-      name: ${ou_liquid_pipe_temp}
-    ou_two_phase_pipe_temp:
-      id: ou_two_phase_pipe_temp
-      name: ${ou_two_phase_pipe_temp}
-    ou_suction_pipe_temp:
-      id: ou_suction_pipe_temp
-      name: ${ou_suction_pipe_temp}
-    ou_heatsink_temp:
-      id: ou_heatsink_temp
-      name: ${ou_heatsink_temp}
-    super_heat_temp:
-      id: super_heat_temp
-      name: ${super_heat_temp}
-    sub_cool_temp:
-      id: sub_cool_temp
-      name: ${sub_cool_temp}
-    fan_speed:
-      id: fan_speed
-      name: ${fan_speed}
     controller_version:
       id: controller_version
       internal: true

--- a/confs/base.yaml
+++ b/confs/base.yaml
@@ -242,6 +242,27 @@ text_sensor:
 
 sensor:
   - platform: ecodan
+    compressor_starts:
+      id: compressor_starts
+      name: ${compressor_starts}
+    discharge_temp:
+      id: discharge_temp
+      name: ${discharge_temp}
+    liquid_pipe_temp:
+      id: liquid_pipe_temp
+      name: ${liquid_pipe_temp}
+    # two_phase_pipe_temp:
+    #   id: two_phase_pipe_temp
+    #   name: two_phase_pipe_temp
+    # super_heat_temp:
+    #   id: super_heat_temp
+    #   name: super_heat_temp
+    # sub_cool_temp:
+    #   id: sub_cool_temp
+    #   name: sub_cool_temp
+    fan_speed:
+      id: fan_speed
+      name: ${fan_speed}
     controller_version:
       id: controller_version
       internal: true

--- a/confs/ecodan-labels-en.yaml
+++ b/confs/ecodan-labels-en.yaml
@@ -117,9 +117,9 @@ substitutions:
   compressor_starts: Accumulated Compressor Starts
   discharge_temp: Discharge Temp
   ou_liquid_pipe_temp: Outside Unit Liquid Pipe 1 Temp
-  ou_two_phase_pipe_temp: Outside Unit Two Phase Pipe Temp
-  ou_suction_pipe_temp: Outside Unit Suction Pipe Temp
-  ou_heatsink_temp: Outside Unit Heatsink Temp
+  # ou_two_phase_pipe_temp: Outside Unit Two Phase Pipe Temp
+  # ou_suction_pipe_temp: Outside Unit Suction Pipe Temp
+  # ou_heatsink_temp: Outside Unit Heatsink Temp
   super_heat_temp: Discharge Superheat Temp
   sub_cool_temp: Subcooling Temp
   fan_speed: Fan Speed

--- a/confs/ecodan-labels-en.yaml
+++ b/confs/ecodan-labels-en.yaml
@@ -114,3 +114,7 @@ substitutions:
   status_multi_zone_zone2: Z2 Working
   fault_code_text: Fault code
   refrigerant_error_code_text: Refrigerant error code
+  compressor_starts: Accumulated Compressor Starts
+  discharge_temp: Discharge Temperature
+  liquid_pipe_temp: Liquid Pipe 1 Temperature
+  fan_speed: Fan Speed

--- a/confs/ecodan-labels-en.yaml
+++ b/confs/ecodan-labels-en.yaml
@@ -120,6 +120,6 @@ substitutions:
   # ou_two_phase_pipe_temp: Outside Unit Two Phase Pipe Temp
   # ou_suction_pipe_temp: Outside Unit Suction Pipe Temp
   # ou_heatsink_temp: Outside Unit Heatsink Temp
-  super_heat_temp: Discharge Superheat Temp
-  sub_cool_temp: Subcooling Temp
+  # super_heat_temp: Discharge Superheat Temp
+  # sub_cool_temp: Subcooling Temp
   fan_speed: Fan Speed

--- a/confs/ecodan-labels-en.yaml
+++ b/confs/ecodan-labels-en.yaml
@@ -115,6 +115,11 @@ substitutions:
   fault_code_text: Fault code
   refrigerant_error_code_text: Refrigerant error code
   compressor_starts: Accumulated Compressor Starts
-  discharge_temp: Discharge Temperature
-  liquid_pipe_temp: Liquid Pipe 1 Temperature
+  discharge_temp: Discharge Temp
+  ou_liquid_pipe_temp: Outside Unit Liquid Pipe 1 Temp
+  ou_two_phase_pipe_temp: Outside Unit Two Phase Pipe Temp
+  ou_suction_pipe_temp: Outside Unit Suction Pipe Temp
+  ou_heatsink_temp: Outside Unit Heatsink Temp
+  super_heat_temp: Discharge Superheat Temp
+  sub_cool_temp: Subcooling Temp
   fan_speed: Fan Speed

--- a/confs/ecodan-labels-es.yaml
+++ b/confs/ecodan-labels-es.yaml
@@ -117,9 +117,6 @@ substitutions:
   compressor_starts: Accumulated Compressor Starts
   discharge_temp: Discharge Temp
   ou_liquid_pipe_temp: Outside Unit Liquid Pipe 1 Temp
-  ou_two_phase_pipe_temp: Outside Unit Two Phase Pipe Temp
-  ou_suction_pipe_temp: Outside Unit Suction Pipe Temp
-  ou_heatsink_temp: Outside Unit Heatsink Temp
   super_heat_temp: Discharge Superheat Temp
   sub_cool_temp: Subcooling Temp
   fan_speed: Fan Speed

--- a/confs/ecodan-labels-es.yaml
+++ b/confs/ecodan-labels-es.yaml
@@ -114,3 +114,7 @@ substitutions:
   status_multi_zone_zone2: Z2 en Funcionamiento
   fault_code_text: Código de Falla
   refrigerant_error_code_text: Código de Error del Refrigerante
+  compressor_starts: Arranques acumulados del compresor
+  discharge_temp: Temperatura de Descarga
+  liquid_pipe_temp: Temperatura del Tubo de Líquido 1
+  fan_speed: Velocidad del Ventilador

--- a/confs/ecodan-labels-es.yaml
+++ b/confs/ecodan-labels-es.yaml
@@ -114,7 +114,12 @@ substitutions:
   status_multi_zone_zone2: Z2 en Funcionamiento
   fault_code_text: Código de Falla
   refrigerant_error_code_text: Código de Error del Refrigerante
-  compressor_starts: Arranques acumulados del compresor
-  discharge_temp: Temperatura de Descarga
-  liquid_pipe_temp: Temperatura del Tubo de Líquido 1
-  fan_speed: Velocidad del Ventilador
+  compressor_starts: Accumulated Compressor Starts
+  discharge_temp: Discharge Temp
+  ou_liquid_pipe_temp: Outside Unit Liquid Pipe 1 Temp
+  ou_two_phase_pipe_temp: Outside Unit Two Phase Pipe Temp
+  ou_suction_pipe_temp: Outside Unit Suction Pipe Temp
+  ou_heatsink_temp: Outside Unit Heatsink Temp
+  super_heat_temp: Discharge Superheat Temp
+  sub_cool_temp: Subcooling Temp
+  fan_speed: Fan Speed

--- a/confs/ecodan-labels-es.yaml
+++ b/confs/ecodan-labels-es.yaml
@@ -114,9 +114,7 @@ substitutions:
   status_multi_zone_zone2: Z2 en Funcionamiento
   fault_code_text: Código de Falla
   refrigerant_error_code_text: Código de Error del Refrigerante
-  compressor_starts: Accumulated Compressor Starts
-  discharge_temp: Discharge Temp
-  ou_liquid_pipe_temp: Outside Unit Liquid Pipe 1 Temp
-  super_heat_temp: Discharge Superheat Temp
-  sub_cool_temp: Subcooling Temp
-  fan_speed: Fan Speed
+  compressor_starts: Arranques acumulados del compresor
+  discharge_temp: Temperatura de descarga
+  ou_liquid_pipe_temp: Tubo de líquido de la unidad exterior 1 Temperatura
+  fan_speed: Velocidad del ventilador

--- a/confs/ecodan-labels-fr.yaml
+++ b/confs/ecodan-labels-fr.yaml
@@ -114,7 +114,12 @@ substitutions:
   status_multi_zone_zone2: Z2 fonctionne
   fault_code_text: Code d'erreur
   refrigerant_error_code_text: Réfrigérant code d'erreur
-  compressor_starts: Démarrages cumulés du Compresseur
-  discharge_temp: Température de décharge
-  liquid_pipe_temp: Température du tuyau de liquide 1
-  fan_speed: Vitesse du ventilateur
+  compressor_starts: Accumulated Compressor Starts
+  discharge_temp: Discharge Temp
+  ou_liquid_pipe_temp: Outside Unit Liquid Pipe 1 Temp
+  ou_two_phase_pipe_temp: Outside Unit Two Phase Pipe Temp
+  ou_suction_pipe_temp: Outside Unit Suction Pipe Temp
+  ou_heatsink_temp: Outside Unit Heatsink Temp
+  super_heat_temp: Discharge Superheat Temp
+  sub_cool_temp: Subcooling Temp
+  fan_speed: Fan Speed

--- a/confs/ecodan-labels-fr.yaml
+++ b/confs/ecodan-labels-fr.yaml
@@ -117,9 +117,6 @@ substitutions:
   compressor_starts: Accumulated Compressor Starts
   discharge_temp: Discharge Temp
   ou_liquid_pipe_temp: Outside Unit Liquid Pipe 1 Temp
-  ou_two_phase_pipe_temp: Outside Unit Two Phase Pipe Temp
-  ou_suction_pipe_temp: Outside Unit Suction Pipe Temp
-  ou_heatsink_temp: Outside Unit Heatsink Temp
   super_heat_temp: Discharge Superheat Temp
   sub_cool_temp: Subcooling Temp
   fan_speed: Fan Speed

--- a/confs/ecodan-labels-fr.yaml
+++ b/confs/ecodan-labels-fr.yaml
@@ -114,9 +114,7 @@ substitutions:
   status_multi_zone_zone2: Z2 fonctionne
   fault_code_text: Code d'erreur
   refrigerant_error_code_text: Réfrigérant code d'erreur
-  compressor_starts: Accumulated Compressor Starts
-  discharge_temp: Discharge Temp
-  ou_liquid_pipe_temp: Outside Unit Liquid Pipe 1 Temp
-  super_heat_temp: Discharge Superheat Temp
-  sub_cool_temp: Subcooling Temp
-  fan_speed: Fan Speed
+  compressor_starts: Démarrages cumulés du compresseur
+  discharge_temp: Température de décharge
+  ou_liquid_pipe_temp: Température du tuyau de liquide 1 de l'unité extérieure
+  fan_speed: Vitesse du ventilateur

--- a/confs/ecodan-labels-fr.yaml
+++ b/confs/ecodan-labels-fr.yaml
@@ -114,3 +114,7 @@ substitutions:
   status_multi_zone_zone2: Z2 fonctionne
   fault_code_text: Code d'erreur
   refrigerant_error_code_text: Réfrigérant code d'erreur
+  compressor_starts: Démarrages cumulés du Compresseur
+  discharge_temp: Température de décharge
+  liquid_pipe_temp: Température du tuyau de liquide 1
+  fan_speed: Vitesse du ventilateur

--- a/confs/ecodan-labels-it.yaml
+++ b/confs/ecodan-labels-it.yaml
@@ -114,9 +114,7 @@ substitutions:
   status_multi_zone_zone2: Z2 funzionante
   fault_code_text: Codice di errore
   refrigerant_error_code_text: Liq. Refr. codice di errore
-  compressor_starts: Accumulated Compressor Starts
-  discharge_temp: Discharge Temp
-  ou_liquid_pipe_temp: Outside Unit Liquid Pipe 1 Temp
-  super_heat_temp: Discharge Superheat Temp
-  sub_cool_temp: Subcooling Temp
-  fan_speed: Fan Speed
+  compressor_starts: Démarrages cumulés du compresseur
+  discharge_temp: Temperatura di scarico
+  ou_liquid_pipe_temp: Temperatura tubo liquido unità esterna 1
+  fan_speed: Velocità della ventola

--- a/confs/ecodan-labels-it.yaml
+++ b/confs/ecodan-labels-it.yaml
@@ -117,9 +117,6 @@ substitutions:
   compressor_starts: Accumulated Compressor Starts
   discharge_temp: Discharge Temp
   ou_liquid_pipe_temp: Outside Unit Liquid Pipe 1 Temp
-  ou_two_phase_pipe_temp: Outside Unit Two Phase Pipe Temp
-  ou_suction_pipe_temp: Outside Unit Suction Pipe Temp
-  ou_heatsink_temp: Outside Unit Heatsink Temp
   super_heat_temp: Discharge Superheat Temp
   sub_cool_temp: Subcooling Temp
   fan_speed: Fan Speed

--- a/confs/ecodan-labels-it.yaml
+++ b/confs/ecodan-labels-it.yaml
@@ -114,3 +114,7 @@ substitutions:
   status_multi_zone_zone2: Z2 funzionante
   fault_code_text: Codice di errore
   refrigerant_error_code_text: Liq. Refr. codice di errore
+  compressor_starts: Avviamenti del compressore accumulati
+  discharge_temp: Temperatura di scarico
+  liquid_pipe_temp: Temperatura tubo liquido 1
+  fan_speed: Velocità della ventola

--- a/confs/ecodan-labels-it.yaml
+++ b/confs/ecodan-labels-it.yaml
@@ -114,7 +114,12 @@ substitutions:
   status_multi_zone_zone2: Z2 funzionante
   fault_code_text: Codice di errore
   refrigerant_error_code_text: Liq. Refr. codice di errore
-  compressor_starts: Avviamenti del compressore accumulati
-  discharge_temp: Temperatura di scarico
-  liquid_pipe_temp: Temperatura tubo liquido 1
-  fan_speed: Velocità della ventola
+  compressor_starts: Accumulated Compressor Starts
+  discharge_temp: Discharge Temp
+  ou_liquid_pipe_temp: Outside Unit Liquid Pipe 1 Temp
+  ou_two_phase_pipe_temp: Outside Unit Two Phase Pipe Temp
+  ou_suction_pipe_temp: Outside Unit Suction Pipe Temp
+  ou_heatsink_temp: Outside Unit Heatsink Temp
+  super_heat_temp: Discharge Superheat Temp
+  sub_cool_temp: Subcooling Temp
+  fan_speed: Fan Speed

--- a/confs/ecodan-labels-nl.yaml
+++ b/confs/ecodan-labels-nl.yaml
@@ -117,9 +117,6 @@ substitutions:
   compressor_starts: Accumulated Compressor Starts
   discharge_temp: Discharge Temp
   ou_liquid_pipe_temp: Outside Unit Liquid Pipe 1 Temp
-  ou_two_phase_pipe_temp: Outside Unit Two Phase Pipe Temp
-  ou_suction_pipe_temp: Outside Unit Suction Pipe Temp
-  ou_heatsink_temp: Outside Unit Heatsink Temp
   super_heat_temp: Discharge Superheat Temp
   sub_cool_temp: Subcooling Temp
   fan_speed: Fan Speed

--- a/confs/ecodan-labels-nl.yaml
+++ b/confs/ecodan-labels-nl.yaml
@@ -114,9 +114,7 @@ substitutions:
   status_multi_zone_zone2: Z2 actief
   fault_code_text: Fout code
   refrigerant_error_code_text: Koelmiddel fout code
-  compressor_starts: Accumulated Compressor Starts
-  discharge_temp: Discharge Temp
-  ou_liquid_pipe_temp: Outside Unit Liquid Pipe 1 Temp
-  super_heat_temp: Discharge Superheat Temp
-  sub_cool_temp: Subcooling Temp
-  fan_speed: Fan Speed
+  compressor_starts: Compressor Starts
+  discharge_temp: Ontladingstemperatuur
+  ou_liquid_pipe_temp: Buitenunit Vloeistofleiding 1
+  fan_speed: Ventilatorsnelheid

--- a/confs/ecodan-labels-nl.yaml
+++ b/confs/ecodan-labels-nl.yaml
@@ -113,4 +113,7 @@ substitutions:
   status_multi_zone_zone1: Z1 actief
   status_multi_zone_zone2: Z2 actief
   fault_code_text: Fout code
-  refrigerant_error_code_text: Koelmiddel fout code
+  compressor_starts: Aantal Compressor Starts
+  discharge_temp: Discharge Temp
+  liquid_pipe_temp: Liquid Pipe 1 Temp
+  fan_speed: Ventilatorsnelheid

--- a/confs/ecodan-labels-nl.yaml
+++ b/confs/ecodan-labels-nl.yaml
@@ -113,7 +113,13 @@ substitutions:
   status_multi_zone_zone1: Z1 actief
   status_multi_zone_zone2: Z2 actief
   fault_code_text: Fout code
-  compressor_starts: Aantal Compressor Starts
+  refrigerant_error_code_text: Koelmiddel fout code
+  compressor_starts: Accumulated Compressor Starts
   discharge_temp: Discharge Temp
-  liquid_pipe_temp: Liquid Pipe 1 Temp
-  fan_speed: Ventilatorsnelheid
+  ou_liquid_pipe_temp: Outside Unit Liquid Pipe 1 Temp
+  ou_two_phase_pipe_temp: Outside Unit Two Phase Pipe Temp
+  ou_suction_pipe_temp: Outside Unit Suction Pipe Temp
+  ou_heatsink_temp: Outside Unit Heatsink Temp
+  super_heat_temp: Discharge Superheat Temp
+  sub_cool_temp: Subcooling Temp
+  fan_speed: Fan Speed

--- a/confs/request-codes.yaml
+++ b/confs/request-codes.yaml
@@ -18,12 +18,13 @@ sensor:
     # ou_heatsink_temp:
     #   id: ou_heatsink_temp
     #   name: ${ou_heatsink_temp}
-    super_heat_temp:
-      id: super_heat_temp
-      name: ${super_heat_temp}
-    sub_cool_temp:
-      id: sub_cool_temp
-      name: ${sub_cool_temp}
+    ## these values can be computed: TH4 (discharge temp) - T63HS (condensing temp), T63HS−TH2 (liquid temp)
+    # super_heat_temp:
+    #   id: super_heat_temp
+    #   name: ${super_heat_temp}
+    # sub_cool_temp:
+    #   id: sub_cool_temp
+    #   name: ${sub_cool_temp}
     fan_speed:
       id: fan_speed
       name: ${fan_speed}

--- a/confs/request-codes.yaml
+++ b/confs/request-codes.yaml
@@ -1,0 +1,29 @@
+sensor:
+  - platform: ecodan
+    compressor_starts:
+      id: compressor_starts
+      name: ${compressor_starts}
+    discharge_temp:
+      id: discharge_temp
+      name: ${discharge_temp}
+    ou_liquid_pipe_temp:
+      id: ou_liquid_pipe_temp
+      name: ${ou_liquid_pipe_temp}
+    # ou_two_phase_pipe_temp:
+    #   id: ou_two_phase_pipe_temp
+    #   name: ${ou_two_phase_pipe_temp}
+    # ou_suction_pipe_temp:
+    #   id: ou_suction_pipe_temp
+    #   name: ${ou_suction_pipe_temp}
+    # ou_heatsink_temp:
+    #   id: ou_heatsink_temp
+    #   name: ${ou_heatsink_temp}
+    super_heat_temp:
+      id: super_heat_temp
+      name: ${super_heat_temp}
+    sub_cool_temp:
+      id: sub_cool_temp
+      name: ${sub_cool_temp}
+    fan_speed:
+      id: fan_speed
+      name: ${fan_speed}

--- a/ecodan-esphome.yaml
+++ b/ecodan-esphome.yaml
@@ -22,7 +22,8 @@ api:
 #   components: [ ecodan ]
 
 # packages:
-#  base: !include confs/base.yaml # 
+#  base: !include confs/base.yaml # required
+#  req: !include confs/request-codes.yaml 
 #  esp32: !include confs/esp32s3.yaml # esp32.yaml for regular board
 #  zone1: !include confs/zone1.yaml
 # # disable if you don't want to use zone 2
@@ -45,8 +46,9 @@ packages:
     ref: main
     refresh: always
     files: [ 
-            confs/base.yaml,        # required
-            confs/esp32s3.yaml,     # confs/esp32.yaml, for regular board
+            confs/base.yaml,            # required
+            confs/request-codes.yaml,   # disable if your unit does not support request codes (service menu)
+            confs/esp32s3.yaml,         # confs/esp32.yaml, for regular board
             confs/zone1.yaml,
             ## enable if you want to use zone 2
             #confs/zone2.yaml,

--- a/ecodan-esphome.yaml
+++ b/ecodan-esphome.yaml
@@ -26,7 +26,7 @@ api:
 #  esp32: !include confs/esp32s3.yaml # esp32.yaml for regular board
 #  zone1: !include confs/zone1.yaml
 # # disable if you don't want to use zone 2
-# # zone2: !include confs/zone2.yaml
+#  zone2: !include confs/zone2.yaml
 # # change language labels to -en for English or -nl for Dutch
 # # substitutions: !include confs/ecodan-labels-nl.yaml
 #  substitutions: !include confs/ecodan-labels-en.yaml


### PR DESCRIPTION
Currently it takes up to 5s (ftc6) or 3s (ftc7) to retrieve the result of a service code request. 
Currently the following code will be requested:
- 003 - Compressor starts (only every 100 is reported)
- 004 - Discharge temperature (TH3)
- 005 - Liquid pipe 1 temperature (TH3)
- 019 - Fan speed

Enable/disable this feature with the line ecodan-esphome.yaml
`confs/request-codes.yaml,   # disable if your unit does not support request codes (service menu)`