### PR TITLE
Create config for Mahtanar 1.4 boards

### DIFF
--- a/confs/esp32c3-mahtanar.yaml
+++ b/confs/esp32c3-mahtanar.yaml
@@ -1,0 +1,58 @@
+# This config is for Mahtanar boards with a revision of 1.4+ (older revisions may have different UART pins)
+substitutions:
+  uart_rx_pin: 1
+  uart_tx_pin: 0
+
+esphome:
+  name: ${name}
+  friendly_name: ${friendlyName}
+
+esp32:
+  board: esp32-c3-devkitc-02
+  framework:
+    type: esp-idf
+    # Custom sdkconfig options
+    sdkconfig_options:
+      COMPILER_OPTIMIZATION_SIZE: y
+      CONFIG_BT_ENABLED: n
+      CONFIG_FREERTOS_USE_TRACE_FACILITY: y
+      CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS: y
+      CONFIG_FREERTOS_USE_STATS_FORMATTING_FUNCTIONS: y
+
+uart:
+  id: uart_ecodan
+  rx_pin:
+    number: GPIO${uart_rx_pin}
+    mode:
+      input: true
+  tx_pin:
+    number: GPIO${uart_tx_pin}
+    mode:
+      output: true
+  baud_rate: 2400
+  parity: EVEN
+  stop_bits: 1
+  debug:
+    direction: BOTH
+    dummy_receiver: false
+    after:
+      delimiter: "\n"
+    sequence:
+      - lambda: UARTDebug::log_hex(direction, bytes, ' ');
+
+###  Status LED
+light:
+  - platform: status_led
+    name: "Status LED"
+    pin:
+      number: GPIO08
+      inverted: true
+      ignore_strapping_warning: true
+    internal: true
+
+sensor:
+  - platform: internal_temperature
+    name: ${internal_esp_temperature}
+    entity_category: diagnostic
+    unit_of_measurement: "°C"
+    device_class: temperature


### PR DESCRIPTION
This PR adds a configuration file for [Mahtanar boards](https://github.com/tinwer-group/mahtanar). I don't have an Ecodan unit myself, but the configuration was successfully tested ([and documented](https://gitlab.raidho.fr/Stephane/heat-pump)) by a user and seemed to work without issue.