### PR TITLE
Fix ODIN vector initialization before hourly updates

### DIFF
--- a/components/asgard_dashboard/asgard_dashboard.cpp
+++ b/components/asgard_dashboard/asgard_dashboard.cpp
@@ -1410,6 +1410,12 @@ void EcodanDashboard::align_odin_day_(int current_day) {
 void EcodanDashboard::update_actual_data(int hour, int day, float actual_cons_kwh, float actual_prod_kwh, float dhw_cons, float dhw_prod, float actual_room_temp, float standby_cons) {
     if (snapshot_mutex_ == NULL || xSemaphoreTake(snapshot_mutex_, pdMS_TO_TICKS(100)) != pdTRUE) return;
 
+    if (!this->odin_data_ready_) {
+        xSemaphoreGive(snapshot_mutex_);
+        return;
+    }
+    this->ensure_odin_vectors_();
+
     if (!std::isnan(actual_cons_kwh)) {
         if (std::isnan(dhw_cons)) dhw_cons = 0.0f;
         if (std::isnan(standby_cons)) standby_cons = 0.0f;
@@ -1421,7 +1427,7 @@ void EcodanDashboard::update_actual_data(int hour, int day, float actual_cons_kw
     // 1. Ensure the 72h window is properly aligned to today BEFORE we update arrays
     align_odin_day_(day);
 
-    int target_idx = 24 + hour; 
+    int target_idx = 24 + hour;
     float hour_cost = NAN, hour_solar = NAN;
     float exp_cons = NAN, exp_prod = NAN, exp_room = NAN, price = NAN;
     float weather = NAN, batt_dis = NAN, op_mode = NAN;
@@ -1439,10 +1445,10 @@ void EcodanDashboard::update_actual_data(int hour, int day, float actual_cons_kw
             float real_mode = 0.0f; // Default OFF (0) / Standby
             if (!std::isnan(dhw_cons) && dhw_cons > 0.03f) {
                 real_mode = 1.0f; // DHW / Legionella
-            } 
+            }
             else if (!std::isnan(actual_cons_kwh) && actual_cons_kwh > 0.05f) {
                 float inst_mode = (operation_mode_ && operation_mode_->has_state()) ? operation_mode_->state : NAN;
-                
+
                 // Modes: 1=DHW, 2=Heat, 3=Cool, 6=Legionella
                 if (inst_mode == 6.0f || inst_mode == 1.0f) {
                     real_mode = 1.0f; // Legionella / DHW fallback
@@ -1558,30 +1564,7 @@ void EcodanDashboard::store_odin_data(int current_hour, int current_day,
         return;
     }
 
-    auto ensure_72 = [](std::vector<float>& v, float fill_val) {
-        if (v.size() != 72) v.assign(72, fill_val);
-    };
-
-    ensure_72(this->odin_expected_end_temp_, NAN);
-    ensure_72(this->odin_energy_, NAN);
-    ensure_72(this->odin_production_, NAN);
-    ensure_72(this->odin_expected_temp_, NAN);
-    ensure_72(this->odin_cost_, NAN);
-    ensure_72(this->odin_actual_dhw_cons_, NAN);
-    ensure_72(this->odin_actual_dhw_prod_, NAN);
-    ensure_72(this->odin_actual_cons_, NAN);
-    ensure_72(this->odin_actual_prod_, NAN);
-    ensure_72(this->odin_actual_room_, NAN);
-    ensure_72(this->odin_actual_standby_cons_, NAN);
-
-    ensure_72(this->odin_battery_discharge_, 0.0f);
-    ensure_72(this->odin_sched_base_, 0.0f);
-    ensure_72(this->odin_sched_min_, 0.0f);
-    ensure_72(this->odin_sched_max_, 0.0f);
-    ensure_72(this->odin_weather_, 0.0f);
-    ensure_72(this->odin_solar_, 0.0f);
-    ensure_72(this->odin_prices_, 0.0f);
-    ensure_72(this->odin_operation_mode_, 0.0f);
+    this->ensure_odin_vectors_();
 
     if (!this->odin_data_ready_) {
         this->odin_data_ready_ = true;

--- a/components/asgard_dashboard/asgard_dashboard.h
+++ b/components/asgard_dashboard/asgard_dashboard.h
@@ -549,6 +549,7 @@ class EcodanDashboard : public Component, public AsyncWebHandler {
     std::vector<float>* vec;  // pointer to the corresponding member vector
   };
   std::array<OdinArrayEntry, 19> odin_array_map_();
+  void ensure_odin_vectors_();
 
   static void lfs_odin_task_(void* arg);
   void lfs_persist_odin_();

--- a/components/asgard_dashboard/asgard_lfs.cpp
+++ b/components/asgard_dashboard/asgard_lfs.cpp
@@ -308,6 +308,28 @@ EcodanDashboard::odin_array_map_() {
     }};
 }
 
+void EcodanDashboard::ensure_odin_vectors_() {
+    for (const auto& entry : odin_array_map_()) {
+        float fill_val = NAN;
+        switch (entry.slot) {
+            case 5:  // battery_discharge
+            case 11: // prices
+            case 12: // weather
+            case 13: // solar
+            case 14: // operation_mode
+            case 15: // sched_base
+            case 16: // sched_min
+            case 17: // sched_max
+                fill_val = 0.0f;
+                break;
+            default:
+                break;
+        }
+
+        if (entry.vec->size() != 72) entry.vec->assign(72, fill_val);
+    }
+}
+
 void EcodanDashboard::lfs_odin_task_(void* arg) {
     auto* self = static_cast<EcodanDashboard*>(arg);
     while (true) {
@@ -365,6 +387,7 @@ void EcodanDashboard::load_odin_data(int current_day) {
     if (!ok) {
         ESP_LOGI(TAG_LFS, "LFS: no valid odin forecast cache found, starting fresh");
         if (this->snapshot_mutex_ != NULL && xSemaphoreTake(this->snapshot_mutex_, pdMS_TO_TICKS(500)) == pdTRUE) {
+            this->ensure_odin_vectors_();
             this->odin_stored_day_ = current_day;
             this->odin_data_ready_ = true;
             xSemaphoreGive(this->snapshot_mutex_);


### PR DESCRIPTION
## Summary

This fixes an ESP32 panic in the Asgard ODIN dashboard path when hourly actual data is recorded before the ODIN 72-hour vectors have been initialized.

The crash was observed once per hour from the `confs/asgard-odin.yaml` hourly lambda:

```text
[E][esp32.crash:332]:   Reason: Fault - StoreProhibited
[E][esp32.crash:337]:   PC:  0x4200D12B  (fault location)
WARNING Decoded 0x4200d12b: esphome::asgard_dashboard::EcodanDashboard::update_actual_data(int, int, float, float, float, float, float, float) at /IDF_PROJECT/src/esphome/components/asgard_dashboard/asgard_dashboard.cpp:1431
WARNING Decoded 0x42030d81: setup()::{lambda()#110}::_FUN() at /data/packages/224a9af1/confs/asgard-odin.yaml:365
```

## Root Cause

When `load_odin_data()` did not find a valid ODIN cache, it marked the ODIN data as ready:

```cpp
this->odin_data_ready_ = true;
```

but it did not initialize the ODIN vectors to the expected 72-slot window.

That allowed the hourly `update_actual_data()` call to pass the readiness check and write into empty vectors such as `odin_actual_cons_`, which could trigger a `StoreProhibited` panic.

## Changes

- Add a shared `ensure_odin_vectors_()` helper that initializes all ODIN vectors to 72 slots.
- Use the helper in `store_odin_data()` instead of duplicating the vector initialization logic.
- Call the helper in the `load_odin_data()` no-cache path before setting `odin_data_ready_ = true`.
- Add a defensive call in `update_actual_data()` before writing hourly actual values.

## Validation

- Built successfully with:

```text
venv/bin/esphome compile my-ecodan-esphome.yaml
```

- Runtime validation: the ESP32 has continued running correctly without the previous hourly crash.